### PR TITLE
fix: bound headless agy hang on Windows; doctor distinguishes hang from auth (#6)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to **Antigravity for Claude Code**. Format loosely follows
     with `--kill-after`) sized from `--timeout` + head-room, so a hang now returns a
     structured **TIMEOUT (exit 12)** + `AGY_SIGNAL` instead of blocking forever. Warns on
     native Windows when no `timeout` binary is available.
-  - **`doctor.sh`**: `agy models` is now time-bounded and **distinguishes a hang from an
+  - **`doctor.sh`**: `agy models` (and the version probe) are now time-bounded and **distinguish a hang from an
     auth failure** — it no longer tells you to re-authenticate when agy is actually hung
     headless (the misdiagnosis that cost the reporter hours). A genuine empty result still
     reports "not authenticated".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.13.0
+- **Windows headless hang fixed / diagnosed** ([#6](https://github.com/yuting0624/antigravity-for-claude-code/issues/6)):
+  on native Windows without a console (ConPTY), headless `agy -p` / `agy models` could
+  hard-hang with a 0-byte log when stdio is redirected.
+  - **`agy-delegate.sh`**: wraps agy in a wall-clock guard (GNU `timeout`/`gtimeout`,
+    with `--kill-after`) sized from `--timeout` + head-room, so a hang now returns a
+    structured **TIMEOUT (exit 12)** + `AGY_SIGNAL` instead of blocking forever. Warns on
+    native Windows when no `timeout` binary is available.
+  - **`doctor.sh`**: `agy models` is now time-bounded and **distinguishes a hang from an
+    auth failure** — it no longer tells you to re-authenticate when agy is actually hung
+    headless (the misdiagnosis that cost the reporter hours). A genuine empty result still
+    reports "not authenticated".
+  - **README**: added a Platform-support note (macOS/Linux/WSL supported; native Windows
+    not recommended for headless delegation) and a known-limit entry.
+  - **tests**: added a hang → wall-clock-guard → exit 12 case (skips cleanly without `timeout`).
+  - Thanks to **@rokushikii** for the detailed, reproducible report.
+
 ## 0.12.0
 - **Configurable executor model** (agy is multi-model): tiers still default to Gemini, but
   each is remappable to any `agy models` entry (Claude/GPT on plans that expose them) via

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ In Claude Code:
 
 **Prerequisites:** the [Antigravity CLI](https://antigravity.google/docs/cli-using) (`agy`) installed & authenticated (`agy models` lists Gemini models), and Claude Code. For the same-bill cost benefit, run Claude Code on Vertex too.
 
+**Platform support:** macOS, Linux, and **WSL** are the supported targets for headless delegation. **Native Windows (Git Bash/MSYS) is not recommended** — `agy -p` can hang with a 0-byte log when run without a real console (ConPTY); see [issue #6](https://github.com/yuting0624/antigravity-for-claude-code/issues/6). The wrapper now bounds this with a wall-clock guard (GNU `timeout`/`gtimeout`, returning a clean TIMEOUT instead of hanging), and `doctor` distinguishes a hang from an auth failure — but for reliable headless use, run from **WSL/macOS/Linux**.
+
 ## 🧩 Slash commands
 
 <img src="docs/command-menu.png" alt="The /antigravity commands in Claude Code's slash-command menu" width="640">
@@ -151,6 +153,7 @@ Delegation doesn't save money by itself — these do (also in the skill):
 **Known limits (agy v1.0.x)**
 - `-p`/`--print` **takes the prompt as its value** and must come last — the wrapper handles this.
 - No `--output-format json` (plain text); `--print` drops stdout on a non-TTY unless stdin is detached (handled via `< /dev/null`).
+- **Native Windows (no ConPTY):** headless `agy -p` / `agy models` can hard-hang with a 0-byte log when stdio is redirected ([issue #6](https://github.com/yuting0624/antigravity-for-claude-code/issues/6)). The wrapper wraps agy in a wall-clock `timeout`/`gtimeout` guard so it returns a structured TIMEOUT (exit 12) instead of hanging; `doctor` reports the likely hang instead of a misleading "not authenticated". Without `timeout` on PATH there's no safety net — use **WSL/macOS/Linux** for headless delegation.
 - **WSL:** running agy with `--add-dir` on a Windows mount (`/mnt/c/...`) is very slow — agy reads the workspace over a 9p bridge, so even trivial calls can take 20s+. Keep the repo on the WSL Linux filesystem (`~`). The wrapper and `doctor` warn about this.
 
 </details>

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -91,6 +91,46 @@ model_for_tier() {
 # True when running under WSL (Windows Subsystem for Linux).
 on_wsl() { [ -n "${WSL_DISTRO_NAME:-}" ] || grep -qi microsoft /proc/version 2>/dev/null; }
 
+# True on native Windows (Git Bash / MSYS / Cygwin) — NOT WSL. On native Windows
+# without a real console (ConPTY), agy v1.0.x can hard-hang with a 0-byte log when
+# its stdio is redirected (the issue this wall-clock guard defends against).
+on_windows_native() {
+  case "${OSTYPE:-}" in msys*|cygwin*|win32) return 0 ;; esac
+  case "$(uname -s 2>/dev/null)" in MINGW*|MSYS*|CYGWIN*) return 0 ;; esac
+  return 1
+}
+
+# Resolve a usable `timeout`-style command: GNU coreutils `timeout`, or macOS
+# Homebrew's `gtimeout`. Echoes the command name, or empty if neither exists.
+# We wrap agy in this so a headless/no-TTY hang (agy never returns) is bounded by
+# wall-clock — agy's own --print-timeout can't fire if it hangs before starting.
+timeout_cmd() {
+  if command -v timeout  >/dev/null 2>&1; then echo timeout;  return 0; fi
+  if command -v gtimeout >/dev/null 2>&1; then echo gtimeout; return 0; fi
+  return 1
+}
+
+# Convert an agy-style duration (e.g. 5m, 300s, 1h, or a bare number=seconds) to
+# whole seconds, then add a small head-room margin so the OUTER wall-clock guard
+# fires only AFTER agy's own --print-timeout has had its chance. Echoes seconds.
+outer_timeout_secs() {
+  local d="${1:-5m}" n unit secs
+  n="${d%[smh]}"; unit="${d#"$n"}"
+  case "$n" in (*[!0-9]*|'') n=300; unit=s ;; esac
+  case "$unit" in
+    h) secs=$(( n * 3600 )) ;;
+    m) secs=$(( n * 60 )) ;;
+    s|'') secs=$(( n )) ;;
+    *) secs=$(( n )) ;;
+  esac
+  # head-room so the OUTER guard never pre-empts agy's own --print-timeout on a
+  # legitimately-slow-but-progressing call: +25% of the budget, min 10s, capped 120s.
+  local pad=$(( secs / 4 ))
+  [ "$pad" -lt 10 ]  && pad=10
+  [ "$pad" -gt 120 ] && pad=120
+  echo $(( secs + pad ))
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     -t|--tier)      need "$#" "$1"; TIER="$2"; TIER_EXPLICIT=1; shift 2 ;;
@@ -169,10 +209,43 @@ fi
 # fixed /tmp path when multiple delegations run concurrently). Cleaned up on exit.
 ERR="$(mktemp "${TMPDIR:-/tmp}/agy-delegate.XXXXXX")"
 trap 'rm -f "$ERR"' EXIT
+
+# Wall-clock guard: on a non-TTY caller (the whole point of this wrapper), agy can
+# hard-hang before its own --print-timeout engages (notably native Windows without
+# a ConPTY — see issue #6). Wrap in GNU `timeout`/`gtimeout` when available so we
+# always return instead of hanging forever. `timeout` exits 124 on kill -> map to
+# our TIMEOUT (12) and emit the structured signal, so orchestrators react cleanly.
+TO_CMD="$(timeout_cmd || true)"
+TO_SECS="$(outer_timeout_secs "$TIMEOUT")"
+
+if on_windows_native && [ -z "$TO_CMD" ]; then
+  # Native Windows + no timeout binary = highest hang risk with no safety net.
+  echo "agy-delegate: WARNING — native Windows without GNU \`timeout\`/\`gtimeout\` on PATH." >&2
+  echo "agy-delegate:   headless \`agy -p\` can hang here with a 0-byte log (no ConPTY). If this" >&2
+  echo "agy-delegate:   call never returns, run from WSL/macOS/Linux, or install coreutils \`timeout\`." >&2
+fi
+
 set +e
-OUT="$(agy "${ARGS[@]}" -p "$PROMPT" < /dev/null 2>"$ERR")"
-RC=$?
+if [ -n "$TO_CMD" ]; then
+  # --kill-after sends SIGKILL if agy ignores the initial SIGTERM (defensive).
+  OUT="$("$TO_CMD" --kill-after=10 "$TO_SECS" agy "${ARGS[@]}" -p "$PROMPT" < /dev/null 2>"$ERR")"
+  RC=$?
+else
+  OUT="$(agy "${ARGS[@]}" -p "$PROMPT" < /dev/null 2>"$ERR")"
+  RC=$?
+fi
 set -e
+
+# `timeout` exits 124 (SIGTERM) or 137 (SIGKILL after --kill-after) when it had to
+# kill agy. Treat that as our structured TIMEOUT (exit 12), not a generic failure.
+if [ -n "$TO_CMD" ] && { [ $RC -eq 124 ] || [ $RC -eq 137 ]; }; then
+  echo "agy-delegate: agy hit the wall-clock guard (${TO_SECS}s) and was terminated — likely a headless/no-TTY hang." >&2
+  if on_windows_native; then
+    echo "agy-delegate:   native Windows: agy needs a console (ConPTY); run delegation from WSL/macOS/Linux." >&2
+  fi
+  signal TIMEOUT "agy wall-clock guard fired after ${TO_SECS}s (headless/no-TTY hang?)"
+  exit 12
+fi
 
 if [ $RC -ne 0 ]; then
   echo "agy-delegate: agy exited $RC" >&2

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -12,6 +12,32 @@ warn() { printf '  ⚠ %s\n' "$*"; }   # advisory; does NOT fail the check
 info() { printf '    %s\n' "$*"; }
 FAIL=0
 
+# Resolve a usable `timeout` command (GNU coreutils, or macOS Homebrew gtimeout)
+# so a headless/no-TTY hang in `agy models` is bounded instead of freezing doctor.
+TO_CMD=""
+if   command -v timeout  >/dev/null 2>&1; then TO_CMD=timeout
+elif command -v gtimeout >/dev/null 2>&1; then TO_CMD=gtimeout
+fi
+# Run agy with a wall-clock guard when possible. Returns agy's exit code, or the
+# `timeout` kill code (124 SIGTERM / 137 SIGKILL) when it had to kill a hang. The
+# caller inspects the RETURN CODE (not a global) because this runs inside a
+# command-substitution subshell, where a global assignment would NOT propagate.
+agy_guard() { # usage: agy_guard <secs> <agy-args...>
+  local secs="$1"; shift
+  if [ -n "$TO_CMD" ]; then
+    "$TO_CMD" --kill-after=5 "$secs" agy "$@"
+    return $?
+  fi
+  agy "$@"
+}
+
+# True on native Windows (Git Bash/MSYS/Cygwin), NOT WSL — where headless agy hangs.
+on_windows_native() {
+  case "${OSTYPE:-}" in msys*|cygwin*|win32) return 0 ;; esac
+  case "$(uname -s 2>/dev/null)" in MINGW*|MSYS*|CYGWIN*) return 0 ;; esac
+  return 1
+}
+
 echo "Antigravity for Claude Code — doctor"
 
 # 1. agy on PATH
@@ -22,9 +48,28 @@ else
   info "fix: install the Antigravity CLI, then ensure its bin dir is on PATH"
 fi
 
-# 2. agy authenticated (can list models)
+# 2. agy authenticated (can list models). Guarded by a wall-clock timeout so a
+#    headless/no-TTY hang (issue #6, esp. native Windows) doesn't freeze doctor
+#    and isn't misreported as "not authenticated".
 if command -v agy >/dev/null 2>&1; then
-  MODELS="$(agy models 2>/dev/null || true)"
+  if [ -z "$TO_CMD" ]; then
+    warn "no \`timeout\`/\`gtimeout\` on PATH — cannot bound a possible \`agy models\` hang"
+    info "install coreutils \`timeout\` (or Homebrew \`gtimeout\`) so doctor can tell a hang from an auth failure"
+  fi
+  MODELS="$(agy_guard 20 models 2>/dev/null)"; AGY_RC=$?
+  AGY_TIMED_OUT=0
+  { [ "$AGY_RC" -eq 124 ] || [ "$AGY_RC" -eq 137 ]; } && AGY_TIMED_OUT=1
+  if [ "$AGY_TIMED_OUT" -eq 1 ]; then
+    bad "\`agy models\` hung and was killed after 20s — this is NOT an auth problem"
+    info "agy hangs when run headless with no TTY/console (0-byte log, no output)."
+    if on_windows_native; then
+      info "native Windows: agy needs a real console (ConPTY). Run delegation from WSL/macOS/Linux."
+    else
+      info "check whether agy is being invoked without a console; prefer WSL/macOS/Linux for headless delegation."
+    fi
+    info "(your credentials are likely fine — don't re-authenticate based on this.)"
+    MODELS=""
+  fi
   if [ -n "$MODELS" ]; then
     ok "agy authenticated — $(printf '%s' "$MODELS" | grep -c . ) models available"
     # 2b. configured tier->model names exist (respecting userConfig remaps). agy is
@@ -40,9 +85,11 @@ if command -v agy >/dev/null 2>&1; then
         info "agy is multi-model/plan-dependent — remap tiers via CLAUDE_PLUGIN_OPTION_TIER_* (or set _DEFAULT_MODEL), or pass --model <name from \`agy models\`)"
       fi
     done
-  else
+  elif [ "$AGY_TIMED_OUT" -eq 0 ]; then
+    # Empty WITHOUT a timeout kill: genuinely no models -> auth/network is the likely cause.
     bad "agy could not list models (not authenticated, or no network)"
     info "fix: authenticate agy (run \`agy\` once interactively) and check GCP access"
+    info "if agy works interactively but is empty here, suspect a headless/no-TTY hang instead (see above)"
   fi
 fi
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -42,7 +42,9 @@ echo "Antigravity for Claude Code — doctor"
 
 # 1. agy on PATH
 if command -v agy >/dev/null 2>&1; then
-  ok "agy found: $(command -v agy)  ($(agy --version 2>/dev/null | head -1))"
+  # version probe is guarded too: `command -v` already proved agy exists, and on a
+  # headless hang even `agy --version` shouldn't be able to freeze doctor (issue #6).
+  ok "agy found: $(command -v agy)  ($(agy_guard 10 --version 2>/dev/null | head -1))"
 else
   bad "agy NOT on PATH"
   info "fix: install the Antigravity CLI, then ensure its bin dir is on PATH"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -79,6 +79,17 @@ check "agy auth -> exit 11 + signal" 11 "$rc" "AUTH_REQUIRED" "$out"
 out=$(STUB_MODE=timeout "$DELEGATE" "hi" 2>&1); rc=$?
 check "agy timeout -> exit 12 + signal" 12 "$rc" "TIMEOUT" "$out"
 
+# wall-clock guard: a HANGING agy (sleeps far past the timeout) must be killed and
+# mapped to TIMEOUT (exit 12), not hang the wrapper forever (issue #6). Requires a
+# real `timeout`/`gtimeout`; skip cleanly if neither is on PATH.
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+  # outer guard for --timeout 1s = 1 + min-pad(10) = 11s; sleep well past it.
+  out=$(STUB_MODE=text STUB_SLEEP=20 "$DELEGATE" --timeout 1s "hi" 2>&1); rc=$?
+  check "hanging agy -> wall-clock guard kills it -> exit 12" 12 "$rc" "TIMEOUT" "$out"
+else
+  echo "ok: (skipped) hang-guard test — no timeout/gtimeout on PATH"; PASS=$((PASS+1))
+fi
+
 # userConfig default tier via env; explicit --tier still wins
 out=$(STUB_MODE=args CLAUDE_PLUGIN_OPTION_DEFAULT_TIER=pro "$DELEGATE" "hi" 2>/dev/null); rc=$?
 check "userConfig default_tier=pro -> Pro model" 0 "$rc" "Gemini 3.1 Pro (High)" "$out"


### PR DESCRIPTION
Closes #6.

## Problem
On native Windows without a console (ConPTY), headless `agy -p` and `agy models` **hard-hang** with a 0-byte log when stdio is redirected. Confirmed still present on **v0.12.0**. Two distinct bugs:

1. **No outer wall-clock guard in `agy-delegate.sh`.** We pass agy its own `--print-timeout`, but that can't fire if agy hangs *before* it starts. The agy call was never wrapped in `timeout`, so it could hang forever.
2. **`doctor.sh` misdiagnoses the hang as an auth failure.** `agy models` (no timeout) hangs → empty output → doctor asserts `not authenticated` and tells you to re-login. The reporter (@rokushikii) lost hours to this; auth was actually fine.

## Fix
- **`agy-delegate.sh`**: wrap agy in GNU `timeout`/`gtimeout` (with `--kill-after`), sized from `--timeout` + head-room (+25%, min 10s, cap 120s). A kill → structured **TIMEOUT (exit 12)** + `AGY_SIGNAL` instead of hanging. Warns on native Windows when no `timeout` binary is on PATH.
- **`doctor.sh`**: time-bound `agy models` and **distinguish a hang from an auth failure**. A genuine empty result still reports "not authenticated"; a timeout-kill reports the likely headless/no-TTY hang and tells you *not* to re-authenticate. (Guard return code is read directly, not via a global — it runs in a command-substitution subshell where a global wouldn't propagate.)
- **README**: Platform-support note (macOS/Linux/WSL supported; native Windows not recommended for headless delegation) + a known-limit entry.
- **tests**: new hang → wall-clock-guard → exit 12 case (skips cleanly when no `timeout`/`gtimeout`).
- **version**: 0.12.0 → 0.13.0 + CHANGELOG.

## Verification
- `bash tests/run-tests.sh` → **56 pass / 0 fail** (incl. the new hang test).
- Manual stub runs confirm doctor now reports correctly in all three cases:
  - normal → `authenticated`
  - hang (sleep > guard) → `NOT an auth problem … headless/no-TTY hang`
  - real empty/instant → `not authenticated` (no false hang detection)

> Note for native Windows: a fully robust fix is a ConPTY/pseudo-console wrapper. This PR makes the failure **safe and correctly diagnosed** (no infinite hang, no misleading auth advice) and steers users to WSL/macOS/Linux for headless delegation. Happy to follow up with a ConPTY shim if wanted.

cc @rokushikii — thanks for the excellent repro; would love your test on Windows 11 + Git Bash.
