### PR TITLE
fix: bin/ entrypoints for marketplace installs (#11) + write-delegation guidance/guard (#10)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.14.0
+- **`bin/` entrypoints — fixes `$CLAUDE_PLUGIN_ROOT` failures on marketplace installs**
+  ([#11](https://github.com/yuting0624/antigravity-for-claude-code/issues/11)):
+  `$CLAUDE_PLUGIN_ROOT` is only substituted in structured config (hooks/MCP/LSP) and is
+  **not** exported to model-run Bash — so commands/skills that ran
+  `"$CLAUDE_PLUGIN_ROOT/scripts/…"` expanded to an empty path and failed. Scripts are now
+  invoked by **bare name via `bin/` shims** (Claude Code adds a plugin's `bin/` to the
+  Bash-tool PATH): `agy-delegate` / `agy-job` / `agy-cost-compare` / `agy-doctor`. Commands,
+  the skill, and the delegate subagent were updated; the PreToolUse gate accepts the bin
+  names; `doctor` checks the shims. (`scripts/` is unchanged — the shims forward to it.)
+- **Write-delegation guidance + guard**
+  ([#10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)): without
+  `--yolo`, headless agy only *describes* edits and returns a confident success **while
+  writing no files**. The `delegate` command now makes `--yolo` explicit for write tasks
+  (on a branch), notes the harness may prompt for / block `--dangerously-skip-permissions`,
+  and flags the ~2-min sync Bash limit (→ background job). `agy-delegate.sh` now warns when a
+  write-looking prompt lacks `--yolo`. (The verification gate already caught the no-write.)
+- Thanks to **@erszcz** (#10) and **@Masterisk-F** (#11) for the reports.
+
 ## 0.13.0
 - **Windows headless hang fixed / diagnosed** ([#6](https://github.com/yuting0624/antigravity-for-claude-code/issues/6)):
   on native Windows without a console (ConPTY), headless `agy -p` / `agy models` could

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Delegation doesn't save money by itself — these do (also in the skill):
 **Known limits (agy v1.0.x)**
 - `-p`/`--print` **takes the prompt as its value** and must come last — the wrapper handles this.
 - No `--output-format json` (plain text); `--print` drops stdout on a non-TTY unless stdin is detached (handled via `< /dev/null`).
+- **Writes need `--yolo`:** without it, headless agy only *describes* edits and returns a confident success **without writing any files** ([issue #10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)). Pass `--yolo` for write tasks (on a branch); Claude Code may prompt for / block `--dangerously-skip-permissions` — approve it or pre-allow it. Long write tasks can exceed the ~2-min sync Bash limit → use a background job.
 - **Native Windows (no ConPTY):** headless `agy -p` / `agy models` can hard-hang with a 0-byte log when stdio is redirected ([issue #6](https://github.com/yuting0624/antigravity-for-claude-code/issues/6)). The wrapper wraps agy in a wall-clock `timeout`/`gtimeout` guard so it returns a structured TIMEOUT (exit 12) instead of hanging; `doctor` reports the likely hang instead of a misleading "not authenticated". Without `timeout` on PATH there's no safety net — use **WSL/macOS/Linux** for headless delegation.
 - **WSL:** running agy with `--add-dir` on a Windows mount (`/mnt/c/...`) is very slow — agy reads the workspace over a 9p bridge, so even trivial calls can take 20s+. Keep the repo on the WSL Linux filesystem (`~`). The wrapper and `doctor` warn about this.
 

--- a/agents/antigravity-delegate.md
+++ b/agents/antigravity-delegate.md
@@ -52,12 +52,12 @@ claim success** — verification is the caller's (Claude's) job.
 ## Core rule — everything goes through the wrapper
 
 You have **no `Write` and no `Edit`**, and a `PreToolUse` gate **blocks every Bash
-command except the delegation wrapper** (`agy-delegate.sh` / `agy-job.sh`). So all
+command except the delegation wrapper** (`agy-delegate` / `agy-job`). So all
 file creation/editing and bulky work must be performed by agy, not by you — you
 cannot write files even via the shell. Never reconstruct file contents in your reply.
 
 ```bash
-"$CLAUDE_PLUGIN_ROOT/scripts/agy-delegate.sh" [options] "<task>"
+agy-delegate [options] "<task>"
 ```
 
 Options: `--tier flash|flash-lo|pro` · `--dir <repo-root>` (so agy reads

--- a/bin/agy-cost-compare
+++ b/bin/agy-cost-compare
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# bin/ entrypoint on the Bash-tool PATH (Claude Code adds a plugin's bin/ to PATH).
+# $CLAUDE_PLUGIN_ROOT is NOT exported to model-run Bash (issue #11), so commands and
+# skills invoke this bare name; it forwards to the implementation in ../scripts/agy-cost-compare.sh.
+exec "$(cd "$(dirname "$0")/.." && pwd)/scripts/agy-cost-compare.sh" "$@"

--- a/bin/agy-delegate
+++ b/bin/agy-delegate
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# bin/ entrypoint on the Bash-tool PATH (Claude Code adds a plugin's bin/ to PATH).
+# $CLAUDE_PLUGIN_ROOT is NOT exported to model-run Bash (issue #11), so commands and
+# skills invoke this bare name; it forwards to the implementation in ../scripts/agy-delegate.sh.
+exec "$(cd "$(dirname "$0")/.." && pwd)/scripts/agy-delegate.sh" "$@"

--- a/bin/agy-doctor
+++ b/bin/agy-doctor
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# bin/ entrypoint on the Bash-tool PATH (Claude Code adds a plugin's bin/ to PATH).
+# $CLAUDE_PLUGIN_ROOT is NOT exported to model-run Bash (issue #11), so commands and
+# skills invoke this bare name; it forwards to the implementation in ../scripts/doctor.sh.
+exec "$(cd "$(dirname "$0")/.." && pwd)/scripts/doctor.sh" "$@"

--- a/bin/agy-job
+++ b/bin/agy-job
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# bin/ entrypoint on the Bash-tool PATH (Claude Code adds a plugin's bin/ to PATH).
+# $CLAUDE_PLUGIN_ROOT is NOT exported to model-run Bash (issue #11), so commands and
+# skills invoke this bare name; it forwards to the implementation in ../scripts/agy-job.sh.
+exec "$(cd "$(dirname "$0")/.." && pwd)/scripts/agy-job.sh" "$@"

--- a/commands/cancel.md
+++ b/commands/cancel.md
@@ -5,6 +5,6 @@ argument-hint: "<job-id>"
 
 Cancel a running background agy job.
 
-Run: `"$CLAUDE_PLUGIN_ROOT/scripts/agy-job.sh" cancel $ARGUMENTS`
+Run: `agy-job cancel $ARGUMENTS`
 
 Confirm to the user whether it was cancelled or had already finished.

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -11,9 +11,14 @@ Task: $ARGUMENTS
 Do this:
 1. Pick a tier (`flash` default; `pro` for hard reasoning). If the task needs the repo,
    add `--dir <repo-root>` so agy reads the real files (don't paste them into context).
-   If the task needs tools (web/Vertex AI Search), add `--yolo`.
+   **If the task WRITES files or uses tools** (implement / scaffold / test-gen / migrate /
+   fix, or web / Vertex AI Search) **add `--yolo`** — without it, agy only *describes* the
+   edits and returns a confident "done" **while writing nothing** (issue #10). Run write
+   tasks on a dedicated branch (+ `--sandbox`). Note: Claude Code may prompt for or block
+   `--yolo` (`--dangerously-skip-permissions`) — approve it when asked, or pre-allow it in
+   settings; non-interactive (`claude -p`) without that permission can't write via agy.
 2. Run **synchronously** (you may be headless — do not background-and-wait):
-   `"$CLAUDE_PLUGIN_ROOT/scripts/agy-delegate.sh" --tier <tier> [--dir .] [--yolo] "<task>"`
+   `agy-delegate --tier <tier> [--dir .] [--yolo] "<task>"`
 3. Ingest only the **result/digest** — do NOT re-read the files agy already handled
    (keeps your context lean; that's where the cost savings come from).
 4. **Verify**: actually run/check the output; never trust a self-reported "done".
@@ -22,9 +27,10 @@ Do this:
 Remember the break-even: only delegate if the offloaded volume clearly exceeds the
 spec + round-trip + verification overhead. Tiny tasks are cheaper to just do yourself.
 
-**Long task, interactive session?** Start it in the background and keep working — keeps
-the prompt cache warm and frees you to do other turns:
-`ID=$("$CLAUDE_PLUGIN_ROOT/scripts/agy-job.sh" start --tier pro --dir . "<task>")`
+**Long task, interactive session?** A sync delegation can also hit Claude Code's ~2-min
+Bash-tool limit — start it in the background and keep working (this also keeps the prompt
+cache warm and frees you to do other turns):
+`ID=$(agy-job start --tier pro --dir . "<task>")`
 then check `/antigravity:status` and collect with `/antigravity:result <id>`.
 (Don't do this when YOU are headless `claude -p` — one-shot, no later turn to collect;
 delegate synchronously there.)

--- a/commands/research.md
+++ b/commands/research.md
@@ -16,10 +16,10 @@ If the topic is empty, ask the user what to research (AskUserQuestion) before st
 Do this:
 1. **Plan (you).** Break the topic into 3–6 sub-questions and list the load-bearing claims that must be verified. You own scope and final synthesis.
 2. **Fan-out fetch (agy, cheap, one call per sub-question).** Web search needs `--yolo` in headless mode; force compact output so bulky pages stay on Gemini's side, not yours:
-   `"$CLAUDE_PLUGIN_ROOT/scripts/agy-delegate.sh" --tier flash --yolo "Web-search <sub-question>. Return 5–8 bullet findings, each with the exact source URL and publication date. Output ONLY findings + URLs + dates."`
+   `agy-delegate --tier flash --yolo "Web-search <sub-question>. Return 5–8 bullet findings, each with the exact source URL and publication date. Output ONLY findings + URLs + dates."`
 3. **Deepen on each load-bearing claim (agy).** Name the URL and have agy quote the supporting sentence(s), turning domain-level citations into verifiable quotes:
-   `"$CLAUDE_PLUGIN_ROOT/scripts/agy-delegate.sh" --tier pro --yolo "Open <URL> and quote the exact sentence(s) supporting: '<claim>'. If the page does not support it, reply NOT SUPPORTED."`
+   `agy-delegate --tier pro --yolo "Open <URL> and quote the exact sentence(s) supporting: '<claim>'. If the page does not support it, reply NOT SUPPORTED."`
 4. **Adversarially verify (you).** Corroborate each key claim across ≥2 independent domains; treat any single / vague / domain-only citation as unverified; sanity-check dates; watch for Gemini parametric knowledge posing as a sourced fact.
 5. **Synthesize (you).** Write a cited report from verified findings only; explicitly mark anything uncorroborated as "unverified".
 
-Keep your own context lean — ingest agy's bullet digests, not the raw pages (that's where the cost savings come from). `--print` does one agentic pass per call, so re-dispatch follow-up agy calls to close gaps rather than expecting it to auto-iterate. In an interactive session a long fetch can be backgrounded with `agy-job.sh`; when **you** are headless (`claude -p`), delegate synchronously.
+Keep your own context lean — ingest agy's bullet digests, not the raw pages (that's where the cost savings come from). `--print` does one agentic pass per call, so re-dispatch follow-up agy calls to close gaps rather than expecting it to auto-iterate. In an interactive session a long fetch can be backgrounded with `agy-job`; when **you** are headless (`claude -p`), delegate synchronously.

--- a/commands/result.md
+++ b/commands/result.md
@@ -5,7 +5,7 @@ argument-hint: "<job-id>"
 
 Fetch and act on a background agy job's result.
 
-Run: `"$CLAUDE_PLUGIN_ROOT/scripts/agy-job.sh" result $ARGUMENTS`
+Run: `agy-job result $ARGUMENTS`
 
 - If it reports "still running", tell the user and stop.
 - If finished: treat the output as a delegated result under the `antigravity` skill's

--- a/commands/review.md
+++ b/commands/review.md
@@ -12,7 +12,7 @@ Do this:
 1. Capture the diff: `git diff` (or the range/paths in the scope above; default to
    uncommitted + last commit if unspecified).
 2. Delegate the review to agy (pro tier) — pipe the diff in on stdin:
-   `git diff | "$CLAUDE_PLUGIN_ROOT/scripts/agy-delegate.sh" --tier pro -`
+   `git diff | agy-delegate --tier pro -`
    with an instruction to find correctness/security/performance bugs, be skeptical, and
    list each as `file:line — issue`. If `--adversarial` is set, also have it challenge the
    design decisions and tradeoffs, not just line bugs.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -4,7 +4,7 @@ description: Verify the Antigravity (agy) CLI is installed and authenticated and
 
 Run the plugin's doctor and report status.
 
-Run: `bash "$CLAUDE_PLUGIN_ROOT/scripts/doctor.sh"`
+Run: `agy-doctor`
 
 Then summarize for the user:
 - Is `agy` installed, and can it list models (i.e. authenticated)?

--- a/commands/status.md
+++ b/commands/status.md
@@ -6,9 +6,9 @@ argument-hint: "[job-id]"
 Show background agy delegation jobs.
 
 - If a job id is given in `$ARGUMENTS`, run:
-  `"$CLAUDE_PLUGIN_ROOT/scripts/agy-job.sh" status $ARGUMENTS`
+  `agy-job status $ARGUMENTS`
 - Otherwise list jobs started from this directory:
-  `"$CLAUDE_PLUGIN_ROOT/scripts/agy-job.sh" list`
+  `agy-job list`
 
 Report each job's id, state (running / done / failed), and task. For finished jobs,
 remind the user they can fetch output with `/antigravity:result <id>`.

--- a/hooks/validate-delegate-bash.sh
+++ b/hooks/validate-delegate-bash.sh
@@ -3,7 +3,7 @@
 # PreToolUse(Bash) gate for the `antigravity-delegate` subagent. Claude Code's
 # subagent `tools:` field can't scope Bash to one command, so this hook enforces it:
 # allow a Bash call ONLY when it invokes the plugin's delegation wrapper
-# (agy-delegate.sh / agy-job.sh); block everything else with exit code 2.
+# (agy-delegate / agy-job); block everything else with exit code 2.
 #
 # This keeps file writing + verification off the delegate subagent (file generation
 # happens on agy/Gemini, not by spending Claude tokens in the shell).
@@ -28,8 +28,8 @@ else
 fi
 
 case "$cmd" in
-  *agy-delegate.sh*|*agy-job.sh*) exit 0 ;;
+  *agy-delegate*|*agy-job*) exit 0 ;;
 esac
 
-echo "[antigravity-delegate] blocked: this subagent may only run agy-delegate.sh / agy-job.sh via Bash. Delegate file work to agy; verification is the caller's job." >&2
+echo "[antigravity-delegate] blocked: this subagent may only run agy-delegate / agy-job via Bash. Delegate file work to agy; verification is the caller's job." >&2
 exit 2

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -188,6 +188,18 @@ if on_wsl; then
   done
 fi
 
+# Heads-up: a likely write task without --yolo. Without --yolo, headless agy only
+# DESCRIBES edits and returns success without writing any files (issue #10). Best-effort
+# heuristic; warn only. --print-command (dry run) is exempt.
+if [ "$YOLO" -eq 0 ] && [ "$PRINT_CMD" -ne 1 ]; then
+  shopt -s nocasematch
+  case "$PROMPT" in
+    *implement*|*scaffold*|*migrate*|*refactor*|*"write the file"*|*"create the file"*|*"edit the file"*)
+      echo "agy-delegate: note: this looks like a write task but --yolo is not set — without it agy only DESCRIBES edits and writes nothing (still returns success). Add --yolo (and run on a branch) to actually write files." >&2 ;;
+  esac
+  shopt -u nocasematch
+fi
+
 # --- assemble agy args ---
 # NOTE: in agy, -p/--print/--prompt TAKES THE PROMPT AS ITS VALUE, so it must come
 # last with the prompt attached. Other flags go before it.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -120,6 +120,14 @@ for h in check-agy.sh inject-policy.sh validate-delegate-bash.sh; do
   fi
 done
 
+# 4b2. bin/ entrypoints executable (added to the Bash-tool PATH; commands/skills call
+#      these bare names — $CLAUDE_PLUGIN_ROOT is not exported to model-run Bash, issue #11)
+for b in agy-delegate agy-job agy-cost-compare agy-doctor; do
+  if [ -x "$ROOT/bin/$b" ]; then ok "bin/$b executable"; else
+    bad "bin/$b not executable"; info "fix: chmod +x \"$ROOT/bin/$b\""
+  fi
+done
+
 # 4c. WSL: agy --add-dir over a Windows mount (/mnt/*) reads via a slow 9p bridge
 if grep -qi microsoft /proc/version 2>/dev/null || [ -n "${WSL_DISTRO_NAME:-}" ]; then
   case "$PWD" in

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.12.0
+version: 0.14.0
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -58,7 +58,7 @@ the cross-model verification value (Claude executing Claude loses both).
 ## How to call it
 
 ```bash
-"$CLAUDE_PLUGIN_ROOT/scripts/agy-delegate.sh" [options] "the task prompt"
+agy-delegate [options] "the task prompt"
 ```
 Options: `--tier flash|flash-lo|pro` · `--dir <path>` (workspace, repeatable) ·
 `--timeout 10m` · `--yolo` (auto-approve tools — needed for any tool use in headless
@@ -75,11 +75,11 @@ wrapper; it returns a digest for you to verify). Either way, *you* still own ver
 
 **Structured failures.** The wrapper exits `10` quota · `11` auth · `12` timeout · `13`
 agy-missing (besides `2` failed / `3` empty) and prints a `AGY_SIGNAL {...}` line on
-stderr; `agy-job.sh status`/`result` surface it, so you can react (e.g. retry quota with
+stderr; `agy-job status`/`result` surface it, so you can react (e.g. retry quota with
 `--continue`) instead of scraping prose.
 
 **If Claude itself is running headless (`claude -p`, one-shot):** run delegations
-**synchronously** — let `agy-delegate.sh` BLOCK and return before you continue. Do NOT
+**synchronously** — let `agy-delegate` BLOCK and return before you continue. Do NOT
 background a delegation expecting a later turn / "harness re-invocation": there is none in
 `-p` mode, so you'd exit before the work finishes. (Backgrounding is only valid in an
 interactive session that will be re-invoked.)
@@ -127,6 +127,10 @@ If wrong: retry on `--tier pro`, sharpen the spec, or do that piece yourself.
 
 Read-only work (search, review, analysis) is low-risk. **When agy writes files or runs
 commands** (`--yolo` grants write + terminal):
+- **Write tasks MUST pass `--yolo`.** Without it, agy only *describes* the edits and returns a
+  confident "done" **without writing anything** (issue #10). Claude Code may also prompt for or
+  block `--dangerously-skip-permissions` — approve it or pre-allow `Bash(agy-delegate*)`. Always
+  verify the files actually changed (the gate catches the silent no-write).
 - Run it on a **dedicated git branch or worktree** so changes are isolated.
 - Add `--sandbox` for execution containment.
 - **Claude reviews the diff before merging** — never auto-merge agy's writes.
@@ -176,12 +180,12 @@ Claude's context lean and the round-trips few. Apply these as hard rules:
 Honest framing for any cost claim: there is **no flat 8×/46%**. Below the break-even the
 hybrid costs more; above it, lean-context routing cuts frontier-model spend by a
 *measured* margin. Quote the measured number and the break-even, never a headline ratio.
-Use `agy-cost-compare.sh` for the per-token gap (estimate; set real Vertex rates first).
+Use `agy-cost-compare` for the per-token gap (estimate; set real Vertex rates first).
 
 ## SDLC recipes
 
 ```bash
-ROOT="$CLAUDE_PLUGIN_ROOT/scripts/agy-delegate.sh"
+ROOT=agy-delegate
 
 # Scaffold from a spec (Claude wrote the spec/architecture)
 "$ROOT" --tier pro --yolo --sandbox --dir ./app \
@@ -249,7 +253,7 @@ unverified.**
 Iteration is Claude's job: `--print` does one agentic pass per call (no auto re-query
 when evidence is thin), so Claude must re-dispatch follow-up agy calls to close gaps.
 Token economics: bulky searched/fetched text is paid in cheap Gemini tokens and
-distilled to bullets+URLs before reaching Claude — use `agy-cost-compare.sh` to show it.
+distilled to bullets+URLs before reaching Claude — use `agy-cost-compare` to show it.
 
 ## What Antigravity brings that Claude lacks natively
 
@@ -268,7 +272,7 @@ Routing deterministic, high-volume work to Gemini Flash (≪ Claude per token) i
 **intelligent model routing**: higher CapEx (this harness) for lower OpEx (cheap model
 does the bulk). Use the cost demo as observability:
 ```bash
-"$CLAUDE_PLUGIN_ROOT/scripts/agy-cost-compare.sh" --tier flash "the task prompt"
+agy-cost-compare --tier flash "the task prompt"
 ```
 Estimates only (chars/4; agy exposes no token API in print mode). Set real Vertex rates
 via `CLAUDE_IN_PER_M`, `CLAUDE_OUT_PER_M`, `GEMINI_IN_PER_M`, `GEMINI_OUT_PER_M`.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -132,6 +132,16 @@ check "--print-command shows the tier model" 0 "$rc" "Pro" "$out"
 out=$(PATH="/usr/bin:/bin" "$DELEGATE" --print-command "hi" 2>/dev/null); rc=$?
 check "--print-command works without agy on PATH" 0 "$rc" "--print-timeout" "$out"
 
+# write-task without --yolo -> warn (agy would only describe, not write) (issue #10)
+out=$(STUB_MODE=args "$DELEGATE" "implement the parser module" 2>&1); rc=$?
+check "write prompt w/o --yolo -> warns" 0 "$rc" "DESCRIBES" "$out"
+out=$(STUB_MODE=args "$DELEGATE" --yolo "implement the parser module" 2>&1); rc=$?
+if printf '%s' "$out" | grep -q "DESCRIBES"; then echo "FAIL: warned even with --yolo"; FAIL=$((FAIL+1));
+else echo "ok: no write-warning when --yolo is set"; PASS=$((PASS+1)); fi
+out=$(STUB_MODE=args "$DELEGATE" "summarize the changelog in 3 bullets" 2>&1); rc=$?
+if printf '%s' "$out" | grep -q "DESCRIBES"; then echo "FAIL: warned for a non-write prompt"; FAIL=$((FAIL+1));
+else echo "ok: no write-warning for a read/summary prompt"; PASS=$((PASS+1)); fi
+
 # WSL slow-mount note: fires only under WSL AND when --add-dir is on /mnt/*
 out=$(WSL_DISTRO_NAME=Ubuntu "$DELEGATE" --dir /mnt/c/proj --print-command "hi" 2>&1); rc=$?
 check "WSL + /mnt --dir -> slow-mount note" 0 "$rc" "9p bridge" "$out"
@@ -181,6 +191,11 @@ printf '%s' '{"tool_input":{"command":"agy-job.sh start --tier pro \"b\""}}' | "
 check "gate allows the job wrapper -> exit 0" 0 "$rc"
 printf '%s' '{"tool_input":{"command":"rm -rf /tmp/x ; cat > f.txt"}}' | "$GATE" >/dev/null 2>&1; rc=$?
 check "gate blocks arbitrary bash -> exit 2" 2 "$rc"
+# gate also accepts the bin-name entrypoints (no .sh) the subagent now calls (issue #11)
+printf '%s' '{"tool_input":{"command":"agy-delegate --tier flash \"x\""}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate allows bin name agy-delegate -> exit 0" 0 "$rc"
+printf '%s' '{"tool_input":{"command":"agy-job status abc"}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate allows bin name agy-job -> exit 0" 0 "$rc"
 
 AGENT="$ROOT/agents/antigravity-delegate.md"
 tl=$(grep -m1 '^tools:' "$AGENT")
@@ -189,6 +204,19 @@ else echo "FAIL: delegate agent tools line unexpected: '$tl'"; FAIL=$((FAIL+1));
 if grep -q "PreToolUse" "$AGENT" && grep -q "validate-delegate-bash.sh" "$AGENT"; then
   echo "ok: delegate agent wires the PreToolUse Bash gate"; PASS=$((PASS+1));
 else echo "FAIL: delegate agent missing PreToolUse gate"; FAIL=$((FAIL+1)); fi
+
+echo "== bin/ entrypoints (issue #11: \$CLAUDE_PLUGIN_ROOT not on model-run Bash) =="
+BIN="$ROOT/bin"
+for b in agy-delegate agy-job agy-cost-compare agy-doctor; do
+  if [ -x "$BIN/$b" ]; then echo "ok: bin/$b executable"; PASS=$((PASS+1));
+  else echo "FAIL: bin/$b missing or not executable"; FAIL=$((FAIL+1)); fi
+done
+# the shim must forward to scripts/ without needing $CLAUDE_PLUGIN_ROOT in the env
+out=$(env -u CLAUDE_PLUGIN_ROOT "$BIN/agy-delegate" --tier pro --print-command "hi" 2>/dev/null); rc=$?
+check "bin/agy-delegate forwards to the wrapper (no CLAUDE_PLUGIN_ROOT)" 0 "$rc" "--print-timeout" "$out"
+out=$(env -u CLAUDE_PLUGIN_ROOT "$BIN/agy-doctor" 2>/dev/null | head -1); rc=$?
+case "$out" in *doctor*) echo "ok: bin/agy-doctor forwards to doctor.sh"; PASS=$((PASS+1));;
+  *) echo "FAIL: bin/agy-doctor did not forward (got: '$out')"; FAIL=$((FAIL+1));; esac
 
 echo "== measure-session.py =="
 SESS="$TMP/sess.jsonl"
@@ -287,6 +315,19 @@ if m: need(os.path.isfile(p(m.group(1))), "agent gate references missing file: "
 
 for s in ("hooks/check-agy.sh", "hooks/inject-policy.sh", "hooks/validate-delegate-bash.sh"):
     need(os.access(p(s), os.X_OK), "not executable: " + s)
+
+# bin/ entrypoints exist + executable (issue #11: $CLAUDE_PLUGIN_ROOT isn't exported
+# to model-run Bash, so commands/skill must call these bare names on the PATH)
+for b in ("agy-delegate", "agy-job", "agy-cost-compare", "agy-doctor"):
+    need(os.access(p("bin", b), os.X_OK), "bin entrypoint missing/not executable: bin/" + b)
+
+# regression guard: commands & skill must NOT invoke $CLAUDE_PLUGIN_ROOT/scripts/* — that
+# path expands empty on marketplace installs (issue #11). They must use the bin names.
+for f in glob.glob(p("commands", "*.md")) + [p("skills", "antigravity", "SKILL.md")]:
+    if os.path.isfile(f):
+        t = open(f).read()
+        need("CLAUDE_PLUGIN_ROOT}/scripts/" not in t and "CLAUDE_PLUGIN_ROOT/scripts/" not in t,
+             "invokes $CLAUDE_PLUGIN_ROOT/scripts (empty on model Bash, issue #11): " + os.path.basename(f))
 
 if errs:
     print("CONTRACT FAIL:")


### PR DESCRIPTION
Fixes #11 and #10.

## #11 — marketplace installs fail: `$CLAUDE_PLUGIN_ROOT` empty on model-run Bash
`$CLAUDE_PLUGIN_ROOT` is only substituted in **structured config** (hooks / MCP / LSP) and is **not** exported into the Bash-tool environment the model runs commands in. So commands and the skill that invoked `"$CLAUDE_PLUGIN_ROOT/scripts/…"` expanded to an empty path and failed once the plugin was installed from the marketplace (it only "worked" under `--plugin-dir` local dev, where the cwd happened to make the relative path resolve).

**Fix:** scripts are now invoked by **bare name via `bin/` shims** — Claude Code adds a plugin's `bin/` directory to the Bash-tool PATH:

- `bin/agy-delegate`, `bin/agy-job`, `bin/agy-cost-compare`, `bin/agy-doctor` (each `exec`s the matching `scripts/*.sh`, resolving its own dir — no env var needed).
- Commands, the skill (`SKILL.md`), and the `antigravity-delegate` subagent updated to the bin names.
- The PreToolUse delegation gate accepts the bin names.
- `doctor` checks the shims are present + executable.
- `scripts/` is unchanged — the shims forward to it.

## #10 — write delegations silently no-op without `--yolo`
Without `--yolo`, headless `agy` only **describes** the edits and returns a confident success **while writing no files**.

**Fix (guidance + guard):**
- `delegate` command makes `--yolo` explicit for write tasks (on a dedicated branch), notes the harness may prompt for / block `--dangerously-skip-permissions`, and flags the ~2-min synchronous Bash limit (→ use a background job for long writes).
- `SKILL.md` safety section: write tasks **MUST** pass `--yolo`; always verify files actually changed.
- `agy-delegate.sh` now prints a warning when a write-looking prompt lacks `--yolo`.
- (The existing verification gate already caught the silent no-write; this makes it explicit up front.)

## Tests / checks
- `tests/run-tests.sh`: bin-shim exec + forward (run with `CLAUDE_PLUGIN_ROOT` unset), gate accepts bin names, write-without-`--yolo` warning (fires on writes, silent with `--yolo` / on read prompts), and a **contract regression guard** asserting no command/skill ever invokes `$CLAUDE_PLUGIN_ROOT/scripts/*` again.
- **67 pass** (was 56) · `shellcheck` clean (incl. `bin/*`) · `claude plugin validate` passes.
- Version → `0.14.0`; CHANGELOG + README updated.

Thanks to @erszcz (#10) and @Masterisk-F (#11) for the reports.