### PR TITLE
feat: /antigravity:cloud-run-debug — agy digests Cloud Run logs, Claude diagnoses

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.15.0
+- **New command — `/antigravity:cloud-run-debug`** (Conductor/Executor demo): diagnose a failing
+  Cloud Run service. agy (Gemini) does the bulk, cheap work — pulling `severity>=ERROR` logs via
+  `gcloud logging read` and clustering them into a structured digest (error clusters /
+  representative stack traces / time distribution / likely root-cause candidates) — and Claude
+  ingests only that digest to infer the root cause and propose a fix. The lean handoff keeps
+  Claude's context (and cost) down.
+  - **Read-only by default** — diagnosis + proposal only. `--apply` is the only write path, and it
+    only ever lands the fix on a dedicated branch with the diff shown for a human to review/merge;
+    nothing is deployed or merged automatically.
+  - **Narrow surface, generic engine:** one user-facing command, but the engine
+    (`scripts/cloud-debug.sh`, shimmed as `bin/cloud-debug`) takes `--resource-type` (default
+    `cloud_run_revision`) so a future gke-/functions-debug can reuse it without a rewrite. The
+    digest reuses `agy-delegate.sh` — no new delegation logic.
+  - **Safety:** uses the existing `gcloud` ADC (never asks for tokens); a missing
+    `roles/logging.viewer` exits with the exact `add-iam-policy-binding` fix.
+  - `doctor` checks the new script/shim; `tests/` stub `gcloud` + `agy` and cover the
+    fetch→digest, default `--since`, read-only (no writes / no `--apply` in the engine), and
+    permission-denied paths.
+
 ## 0.14.0
 - **`bin/` entrypoints — fixes `$CLAUDE_PLUGIN_ROOT` failures on marketplace installs**
   ([#11](https://github.com/yuting0624/antigravity-for-claude-code/issues/11)):

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ In Claude Code:
 | `/antigravity:delegate [--tier flash\|pro] <task>` | delegate a subtask to agy under cost discipline, then verify |
 | `/antigravity:review [--adversarial]` | independent cross-model review of the current diff; Claude reconciles |
 | `/antigravity:research <topic>` | Claude-orchestrated deep research — agy does grounded web legwork, Claude verifies citations across ≥2 sources |
+| `/antigravity:cloud-run-debug [--service <s>] [--region <r>] [--since 1h] [--apply]` | diagnose a failing Cloud Run service — agy digests the error logs, Claude infers the root cause + fix; read-only by default (`--apply` writes to a branch) |
 | `/antigravity:status [id]` · `:result <id>` · `:cancel <id>` | manage background delegation jobs |
 
 > Background jobs are for **interactive** sessions (fire-and-collect). In headless `claude -p` (one-shot), delegate **synchronously** — there's no later turn to collect a result.
@@ -166,9 +167,9 @@ Delegation doesn't save money by itself — these do (also in the skill):
 .claude-plugin/   plugin (+ userConfig: default_tier, timeout, coding_policy) + marketplace manifests
 skills/antigravity/SKILL.md   WHEN + HOW Claude collaborates with agy
 agents/           antigravity-delegate subagent (file work runs on Gemini, not Claude)
-commands/         slash commands (delegate, review, research, setup, status, result, cancel)
+commands/         slash commands (delegate, review, research, cloud-run-debug, setup, status, result, cancel)
 hooks/            SessionStart: agy health check + auto-inject the cost-aware policy
-scripts/          agy-delegate · agy-job · agy-cost-compare · measure-session · doctor
+scripts/          agy-delegate · agy-job · agy-cost-compare · cloud-debug · measure-session · doctor
 docs/             AB-RESULTS (measured A/B) · DEMO-KIT
 prices.json       Vertex rate config (verify before quoting)
 ```

--- a/bin/cloud-debug
+++ b/bin/cloud-debug
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# bin/ entrypoint on the Bash-tool PATH (Claude Code adds a plugin's bin/ to PATH).
+# $CLAUDE_PLUGIN_ROOT is NOT exported to model-run Bash (issue #11), so commands and
+# skills invoke this bare name; it forwards to the implementation in ../scripts/cloud-debug.sh.
+exec "$(cd "$(dirname "$0")/.." && pwd)/scripts/cloud-debug.sh" "$@"

--- a/commands/cloud-run-debug.md
+++ b/commands/cloud-run-debug.md
@@ -1,0 +1,51 @@
+---
+description: Diagnose a failing Cloud Run service — Antigravity (agy/Gemini) digests the error logs cheaply, Claude infers the root cause and proposes a fix. Read-only by default; --apply writes the fix to a branch.
+argument-hint: "[--service <name>] [--region <r>] [--since 1h] [--limit 200] [--apply]"
+---
+
+Diagnose a broken Cloud Run service. This is a **Conductor / Executor** split: **you (Claude)
+conduct** — confirm scope, reason about the root cause, and propose the fix — while the cheap,
+high-volume work (pulling and clustering potentially hundreds of error log lines) is **offloaded
+to agy (Gemini)** so your context stays lean. You ingest only agy's digest, never the raw logs.
+
+Flags: $ARGUMENTS
+
+Defaults: `--since 1h`, `--limit 200`, **read-only** (diagnosis only). `--apply` is the only
+thing that writes anything, and only ever onto a branch for human review.
+
+Do this:
+
+1. **Resolve scope.** Parse the flags above.
+   - `--service` is required. If it's missing, ask the user which Cloud Run service to diagnose
+     (AskUserQuestion) — there is no "default service".
+   - `--region` is optional; if omitted, logs across all regions are queried. If the user's
+     `gcloud config` has a default region you can offer it.
+   - Never ask for or handle credentials/tokens — the engine uses the existing `gcloud` ADC.
+
+2. **Fetch + digest (delegate to agy — one batch, not parallel).** Run the plugin's read-only
+   engine, which pulls `severity>=ERROR` logs via `gcloud logging read` and hands them to agy for
+   a structured digest (error clusters / representative stack traces / time distribution / likely
+   root-cause candidates):
+   `cloud-debug --service <name> [--region <r>] [--since <dur>] [--limit <n>]`
+   - **Ingest only the digest** it prints — do **not** re-fetch or paste the raw logs into your
+     context (that lean handoff is where the cost saving comes from).
+   - If it exits **3** (permission denied), relay the `roles/logging.viewer` guidance it printed
+     and stop — the user must grant access first. Exit **4** means `gcloud` isn't installed.
+   - If it reports no matching logs, widen `--since` / lower severity, or re-confirm the
+     service/region with the user.
+
+3. **Diagnose (you).** From the digest, infer the most likely root cause (e.g. a missing env var,
+   an unhandled exception, bad config, a dependency timeout). State the reasoning and the evidence
+   (which cluster / trace supports it). Then propose a **concrete fix** — the exact code, config,
+   or environment change — and how to verify it.
+
+4. **Apply only if `--apply` was passed.** Default is diagnosis-only; do **not** modify anything
+   without `--apply`.
+   - Work on a **dedicated branch** (create/switch to one; never the user's working branch).
+   - Apply the proposed fix, then **show the diff** and stop. Do **not** deploy and do **not**
+     merge — a human reviews and merges.
+   - Confirm before any destructive or hard-to-reverse step.
+
+Keep it tight: the demo is Claude conducting the diagnosis while a cheaper model does the log
+grunt-work. Report what you delegated, the root cause you landed on, and the fix (plus the diff
+if `--apply`).

--- a/scripts/cloud-debug.sh
+++ b/scripts/cloud-debug.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# cloud-debug.sh — fetch a GCP resource's recent ERROR logs and hand them to
+# Antigravity (`agy` / Gemini) for a compact, structured digest.
+# Part of the "Antigravity for Claude Code" plugin.
+#
+# This is the Executor half of the /antigravity:cloud-run-debug command:
+# Claude (the Conductor) reasons about root cause + the fix; the bulk, cheap
+# work — pulling potentially hundreds of log lines and clustering them into a
+# digest — is offloaded here to agy so Claude's context stays lean.
+#
+# It is deliberately READ-ONLY: it reads logs and produces a digest. It never
+# applies fixes and never writes to your project (the `--apply` flow lives in
+# the command, driven by Claude on a branch). The default resource type is
+# Cloud Run (cloud_run_revision); `--resource-type` is parameterized so the
+# same engine can back a future gke-debug / functions-debug without a rewrite.
+#
+# The agy digest step reuses scripts/agy-delegate.sh (the plugin's one
+# delegation wrapper) — no new delegation logic here.
+#
+# Usage:
+#   cloud-debug.sh --service <name> [options]
+#
+# Options:
+#   -s, --service <name>           Cloud Run service name (required)
+#   -r, --region  <r>             Location/region (omit to query all regions)
+#       --since <dur>             Log freshness window, e.g. 1h, 30m, 2d (default: 1h)
+#       --limit <n>              Max log entries to fetch (default: 200)
+#       --severity <SEV>         Minimum severity (default: ERROR)
+#       --resource-type <type>    GCP resource.type (default: cloud_run_revision)
+#   -p, --project <id>           GCP project (default: gcloud config's project)
+#   -t, --tier <flash|flash-lo|pro>  agy tier for the digest (default: flash)
+#       --print-command          Print the resolved gcloud + agy commands and exit (dry run)
+#   -h, --help                   Show this help
+#
+# Exit codes:
+#   0  ok (digest printed, or query succeeded with no matching logs)
+#   1  usage error
+#   2  gcloud read failed (generic)
+#   3  permission denied — needs roles/logging.viewer (guidance printed)
+#   4  gcloud not on PATH
+#   5  agy digest step failed (agy-delegate stderr is surfaced)
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DELEGATE="$HERE/agy-delegate.sh"
+
+SERVICE=""
+REGION=""
+SINCE="1h"
+LIMIT="200"
+SEVERITY="ERROR"
+RESOURCE_TYPE="cloud_run_revision"
+PROJECT=""
+TIER="flash"
+PRINT_CMD=0
+
+die() { echo "cloud-debug: $*" >&2; exit 1; }
+# $1 = remaining argc ($#). Fail clearly when an option is missing its value
+# (mirrors agy-delegate.sh so `shift 2` never aborts cryptically under set -e).
+need() { [ "$1" -ge 2 ] || die "option '$2' needs a value"; }
+
+# Print the header comment between "# Usage:" and "# Exit codes:" (anchored to
+# content, not line numbers — same trick as agy-delegate.sh).
+usage() { sed -n '/^# Usage:/,/^# Exit codes:/p' "$0" | sed 's/^# \{0,1\}//'; exit 0; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -s|--service)       need "$#" "$1"; SERVICE="$2"; shift 2 ;;
+    -r|--region)        need "$#" "$1"; REGION="$2"; shift 2 ;;
+    --since)            need "$#" "$1"; SINCE="$2"; shift 2 ;;
+    --limit)            need "$#" "$1"; LIMIT="$2"; shift 2 ;;
+    --severity)         need "$#" "$1"; SEVERITY="$2"; shift 2 ;;
+    --resource-type)    need "$#" "$1"; RESOURCE_TYPE="$2"; shift 2 ;;
+    -p|--project)       need "$#" "$1"; PROJECT="$2"; shift 2 ;;
+    -t|--tier)          need "$#" "$1"; TIER="$2"; shift 2 ;;
+    --print-command)    PRINT_CMD=1; shift ;;
+    -h|--help)          usage ;;
+    --)                 shift; break ;;
+    -*)                 die "unknown option '$1'" ;;
+    *)                  die "unexpected argument '$1' (this command takes only options)" ;;
+  esac
+done
+
+[ -n "$SERVICE" ] || die "no --service given (the Cloud Run service to diagnose)"
+case "$LIMIT" in (*[!0-9]*|'') die "--limit must be a positive integer (got '$LIMIT')" ;; esac
+
+# gcloud is required for the real run; --print-command is a dry run (introspection)
+# and only resolves the project from gcloud config when it's available.
+if [ "$PRINT_CMD" -ne 1 ] && ! command -v gcloud >/dev/null 2>&1; then
+  echo "cloud-debug: 'gcloud' not found on PATH — install the Google Cloud CLI first:" >&2
+  echo "cloud-debug:   https://cloud.google.com/sdk/docs/install" >&2
+  exit 4
+fi
+
+# Resolve the project: explicit --project wins, else gcloud's configured project.
+if [ -z "$PROJECT" ] && command -v gcloud >/dev/null 2>&1; then
+  PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+  # gcloud emits "(unset)" when no project is configured — treat that as empty.
+  [ "$PROJECT" = "(unset)" ] && PROJECT=""
+fi
+if [ -z "$PROJECT" ]; then
+  if [ "$PRINT_CMD" -eq 1 ]; then
+    PROJECT="<project>"   # placeholder so the dry run still renders a full command
+  else
+    die "no GCP project (pass --project <id>, or run 'gcloud config set project <id>')"
+  fi
+fi
+
+# --- build the Logging filter ---
+# Default labels are Cloud Run's (service_name / location). Other resource types
+# may key these differently; that's the seam a future gke/functions command
+# would adjust. severity>=ERROR (overridable) keeps the volume — and cost — bounded.
+FILTER="resource.type=\"$RESOURCE_TYPE\""
+FILTER="$FILTER AND resource.labels.service_name=\"$SERVICE\""
+[ -n "$REGION" ] && FILTER="$FILTER AND resource.labels.location=\"$REGION\""
+FILTER="$FILTER AND severity>=$SEVERITY"
+
+GCLOUD_ARGS=(logging read "$FILTER"
+  "--freshness=$SINCE" "--limit=$LIMIT" --format=json "--project=$PROJECT")
+
+# --- the digest instruction handed to agy alongside the logs ---
+# Worded as a summary task (no implement/scaffold/migrate words) so agy-delegate's
+# write-task heuristic doesn't fire — this stage only reads and reports.
+read -r -d '' INSTRUCTION <<'PROMPT' || true
+You are a log-analysis assistant. Below is a JSON array of GCP log entries at
+the requested severity or higher. Produce a COMPACT, structured digest — do NOT
+echo the raw logs back. Use exactly these sections:
+
+## ERROR CLUSTERS
+Group entries by error signature (normalize variable bits like ids, hashes,
+timestamps). For each cluster give: a one-line label, the count, and first/last
+seen time.
+
+## REPRESENTATIVE STACK TRACE(S)
+For the top 1-3 clusters, the single most representative stack trace or error
+message, trimmed to the relevant frames.
+
+## TIME DISTRIBUTION
+One or two lines: were the errors bursty or steady? any spike, and when?
+
+## LIKELY ROOT-CAUSE CANDIDATES
+2-5 ranked hypotheses, each one line, naming which cluster supports it
+(e.g. missing env var, unhandled exception, bad config, dependency/timeout).
+
+Be concise. Output ONLY the digest.
+
+--- LOG ENTRIES (JSON) ---
+PROMPT
+
+# --- dry run: show the resolved pipeline and exit (no gcloud / agy call) ---
+if [ "$PRINT_CMD" -eq 1 ]; then
+  { printf 'gcloud'; printf ' %q' "${GCLOUD_ARGS[@]}"; printf '\n'; }
+  printf '  | %s --tier %q -\n' "$DELEGATE" "$TIER"
+  exit 0
+fi
+
+# --- fetch logs ---
+ERR="$(mktemp "${TMPDIR:-/tmp}/cloud-debug.XXXXXX")"
+trap 'rm -f "$ERR"' EXIT
+
+set +e
+LOGS="$(gcloud "${GCLOUD_ARGS[@]}" 2>"$ERR")"
+RC=$?
+set -e
+
+if [ "$RC" -ne 0 ]; then
+  echo "cloud-debug: gcloud logging read failed (exit $RC)" >&2
+  [ -s "$ERR" ] && cat "$ERR" >&2
+  # Classify a permissions failure so we can point at the exact role to grant.
+  blob="$(cat "$ERR" 2>/dev/null)"
+  shopt -s nocasematch
+  case "$blob" in
+    *permission_denied*|*"does not have permission"*|*"permission to access"*|*"logging.logEntries.list"*|*"403"*)
+      shopt -u nocasematch
+      echo "cloud-debug: this looks like a permissions problem — your account needs Logs Viewer." >&2
+      echo "cloud-debug:   grant roles/logging.viewer on project '$PROJECT', e.g.:" >&2
+      echo "cloud-debug:   gcloud projects add-iam-policy-binding $PROJECT \\" >&2
+      echo "cloud-debug:     --member='user:YOUR_EMAIL' --role='roles/logging.viewer'" >&2
+      exit 3 ;;
+  esac
+  shopt -u nocasematch
+  exit 2
+fi
+
+# No matching logs is a valid diagnostic result, not an error.
+case "${LOGS//[[:space:]]/}" in
+  ''|'[]')
+    echo "cloud-debug: no logs at severity>=$SEVERITY for service '$SERVICE'${REGION:+ in $REGION} within --since $SINCE."
+    echo "cloud-debug: widen the window (--since), lower --severity, or confirm the service name/region."
+    exit 0 ;;
+esac
+
+# --- delegate the digest to agy (cheap tier; lean output back to Claude) ---
+set +e
+DIGEST="$(printf '%s\n%s\n' "$INSTRUCTION" "$LOGS" | "$DELEGATE" --tier "$TIER" - 2>"$ERR")"
+RC=$?
+set -e
+
+if [ "$RC" -ne 0 ]; then
+  echo "cloud-debug: agy digest step failed (agy-delegate exit $RC)" >&2
+  [ -s "$ERR" ] && cat "$ERR" >&2
+  exit 5
+fi
+
+printf '%s\n' "$DIGEST"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -107,7 +107,7 @@ else
 fi
 
 # 4. plugin scripts executable
-for s in agy-delegate.sh agy-cost-compare.sh; do
+for s in agy-delegate.sh agy-cost-compare.sh cloud-debug.sh; do
   if [ -x "$HERE/$s" ]; then ok "$s executable"; else
     bad "$s not executable"; info "fix: chmod +x \"$HERE/$s\""
   fi
@@ -122,7 +122,7 @@ done
 
 # 4b2. bin/ entrypoints executable (added to the Bash-tool PATH; commands/skills call
 #      these bare names — $CLAUDE_PLUGIN_ROOT is not exported to model-run Bash, issue #11)
-for b in agy-delegate agy-job agy-cost-compare agy-doctor; do
+for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug; do
   if [ -x "$ROOT/bin/$b" ]; then ok "bin/$b executable"; else
     bad "bin/$b not executable"; info "fix: chmod +x \"$ROOT/bin/$b\""
   fi

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -30,7 +30,33 @@ case "${STUB_MODE:-text}" in
 esac
 STUB
 chmod +x "$TMP/bin/agy"
+
+# --- stub `gcloud` on PATH; logging-read behavior controlled by $GCLOUD_MODE ----
+cat > "$TMP/bin/gcloud" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "config" ]; then echo "stub-project"; exit 0; fi   # config get-value project
+if [ "$1" = "logging" ] && [ "$2" = "read" ]; then
+  case "${GCLOUD_MODE:-logs}" in
+    perm)  echo "ERROR: (gcloud.logging.read) PERMISSION_DENIED: caller does not have permission logging.logEntries.list" >&2; exit 1 ;;
+    empty) echo "[]" ;;
+    fail)  echo "ERROR: (gcloud.logging.read) something broke" >&2; exit 1 ;;
+    *)     echo '[{"severity":"ERROR","textPayload":"KeyError: DATABASE_URL","timestamp":"2026-06-28T00:00:00Z"}]' ;;
+  esac
+  exit 0
+fi
+echo "gcloud-stub: unhandled args: $*" >&2; exit 99
+STUB
+chmod +x "$TMP/bin/gcloud"
+
 export PATH="$TMP/bin:$PATH"
+
+# A minimal PATH dir with common utils but deliberately NO gcloud/agy, so
+# "missing on PATH" tests stay deterministic on runners that ship gcloud in
+# /usr/bin (GitHub-hosted ubuntu does — so PATH=/usr/bin:/bin would still find it).
+mkdir -p "$TMP/min"
+for u in bash sh env dirname basename pwd sed cat mktemp grep tr cut find wc head tail sort uniq sleep python3 rm chmod; do
+  s="$(command -v "$u" 2>/dev/null)" && ln -sf "$s" "$TMP/min/$u"
+done
 
 check() { # desc  expected_rc  actual_rc  [substr]  [actual_out]
   local desc="$1" erc="$2" arc="$3" sub="${4:-}" out="${5:-}"
@@ -149,6 +175,54 @@ out=$(WSL_DISTRO_NAME=Ubuntu "$DELEGATE" --dir /home/u/proj --print-command "hi"
 if printf '%s' "$out" | grep -q "9p bridge"; then echo "FAIL: slow-mount note fired for a Linux-FS --dir"; FAIL=$((FAIL+1));
 else echo "ok: no slow-mount note for a Linux-FS --dir"; PASS=$((PASS+1)); fi
 
+echo "== cloud-debug.sh (Cloud Run log digest engine) =="
+CLOUD="$ROOT/scripts/cloud-debug.sh"
+
+# (a) logs fetched -> handed to agy -> digest printed (exit 0). agy stub -> STUB_OK.
+out=$(GCLOUD_MODE=logs "$CLOUD" --service svc 2>/dev/null); rc=$?
+check "logs -> agy digest -> exit 0" 0 "$rc" "STUB_OK" "$out"
+
+# (b) --since defaults to 1h; an explicit --since wins. (dry run; no calls made)
+out=$("$CLOUD" --service svc --print-command 2>/dev/null); rc=$?
+check "default --since -> --freshness=1h" 0 "$rc" "--freshness=1h" "$out"
+out=$("$CLOUD" --service svc --since 3h --print-command 2>/dev/null); rc=$?
+check "explicit --since overrides default" 0 "$rc" "--freshness=3h" "$out"
+
+# the resolved gcloud verb is READ-only (logging read), and the resource type is
+# parameterized (default cloud_run_revision; overridable for a future gke/functions cmd)
+check "engine uses read-only 'logging read'" 0 "$rc" "logging read" "$out"
+out=$("$CLOUD" --service svc --print-command 2>/dev/null); rc=$?
+check "default resource type is cloud_run_revision" 0 "$rc" "cloud_run_revision" "$out"
+out=$("$CLOUD" --service svc --resource-type k8s_container --print-command 2>/dev/null); rc=$?
+check "--resource-type is parameterized" 0 "$rc" "k8s_container" "$out"
+
+# (c) read-only: no --apply path in the engine, and a real run writes no files to CWD.
+out=$("$CLOUD" --service svc --apply 2>/dev/null); rc=$?
+check "engine rejects --apply (write path is command-level, not here)" 1 "$rc"
+WORK="$TMP/cdwork"; mkdir -p "$WORK"
+( cd "$WORK" && GCLOUD_MODE=logs "$CLOUD" --service svc >/dev/null 2>&1 )
+nf=$(find "$WORK" -type f | wc -l)
+if [ "$nf" -eq 0 ]; then echo "ok: a diagnosis run writes no files to the project"; PASS=$((PASS+1));
+else echo "FAIL: cloud-debug wrote $nf file(s) to CWD on a read-only run"; FAIL=$((FAIL+1)); fi
+
+# (d) missing roles/logging.viewer -> exit 3 with actionable guidance
+out=$(GCLOUD_MODE=perm "$CLOUD" --service svc 2>&1); rc=$?
+check "permission denied -> exit 3 + logging.viewer guidance" 3 "$rc" "logging.viewer" "$out"
+
+# misc: required --service, generic gcloud failure, gcloud missing, no logs
+out=$("$CLOUD" 2>/dev/null); rc=$?
+check "missing --service -> exit 1" 1 "$rc"
+out=$(GCLOUD_MODE=fail "$CLOUD" --service svc 2>/dev/null); rc=$?
+check "generic gcloud failure -> exit 2" 2 "$rc"
+out=$(PATH="$TMP/min" "$CLOUD" --service svc 2>&1); rc=$?
+check "gcloud missing on PATH -> exit 4" 4 "$rc" "gcloud" "$out"
+out=$(GCLOUD_MODE=empty "$CLOUD" --service svc 2>/dev/null); rc=$?
+check "no matching logs -> exit 0 + clear note" 0 "$rc" "no logs" "$out"
+
+# agy digest step failure surfaces as exit 5 (logs fetched fine, agy errored)
+out=$(GCLOUD_MODE=logs STUB_MODE=fail "$CLOUD" --service svc 2>/dev/null); rc=$?
+check "agy digest failure -> exit 5" 5 "$rc"
+
 echo "== hooks =="
 HOOKS="$ROOT/hooks"
 
@@ -207,7 +281,7 @@ else echo "FAIL: delegate agent missing PreToolUse gate"; FAIL=$((FAIL+1)); fi
 
 echo "== bin/ entrypoints (issue #11: \$CLAUDE_PLUGIN_ROOT not on model-run Bash) =="
 BIN="$ROOT/bin"
-for b in agy-delegate agy-job agy-cost-compare agy-doctor; do
+for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug; do
   if [ -x "$BIN/$b" ]; then echo "ok: bin/$b executable"; PASS=$((PASS+1));
   else echo "FAIL: bin/$b missing or not executable"; FAIL=$((FAIL+1)); fi
 done
@@ -217,6 +291,8 @@ check "bin/agy-delegate forwards to the wrapper (no CLAUDE_PLUGIN_ROOT)" 0 "$rc"
 out=$(env -u CLAUDE_PLUGIN_ROOT "$BIN/agy-doctor" 2>/dev/null | head -1); rc=$?
 case "$out" in *doctor*) echo "ok: bin/agy-doctor forwards to doctor.sh"; PASS=$((PASS+1));;
   *) echo "FAIL: bin/agy-doctor did not forward (got: '$out')"; FAIL=$((FAIL+1));; esac
+out=$(env -u CLAUDE_PLUGIN_ROOT "$BIN/cloud-debug" --service svc --print-command 2>/dev/null); rc=$?
+check "bin/cloud-debug forwards to cloud-debug.sh (no CLAUDE_PLUGIN_ROOT)" 0 "$rc" "logging read" "$out"
 
 echo "== measure-session.py =="
 SESS="$TMP/sess.jsonl"
@@ -318,7 +394,7 @@ for s in ("hooks/check-agy.sh", "hooks/inject-policy.sh", "hooks/validate-delega
 
 # bin/ entrypoints exist + executable (issue #11: $CLAUDE_PLUGIN_ROOT isn't exported
 # to model-run Bash, so commands/skill must call these bare names on the PATH)
-for b in ("agy-delegate", "agy-job", "agy-cost-compare", "agy-doctor"):
+for b in ("agy-delegate", "agy-job", "agy-cost-compare", "agy-doctor", "cloud-debug"):
     need(os.access(p("bin", b), os.X_OK), "bin entrypoint missing/not executable: bin/" + b)
 
 # regression guard: commands & skill must NOT invoke $CLAUDE_PLUGIN_ROOT/scripts/* — that


### PR DESCRIPTION
## What

Adds a new slash command, **`/antigravity:cloud-run-debug`**, that diagnoses a failing Cloud Run service.

```
/antigravity:cloud-run-debug [--service <name>] [--region <r>] [--since 1h] [--limit 200] [--apply]
```

## Why — Conductor / Executor split

This command is, first and foremost, a demonstration of the plugin's core idea. **Claude conducts** — it confirms scope, reasons about the root cause, and proposes the fix — while the bulk, cheap, deterministic work (pulling potentially hundreds of `severity>=ERROR` log lines via `gcloud logging read` and clustering them into a structured digest) is **offloaded to the Executor, agy (Gemini)**. Claude ingests only agy's digest — error clusters / representative stack traces / time distribution / likely root-cause candidates — never the raw logs, so its context (and cost) stays lean. That lean handoff is the whole point.

## Design intent — narrow surface, generic engine

The **marketed surface is deliberately narrow**: one user-facing command, Cloud Run only. The **engine underneath is generic**: `scripts/cloud-debug.sh` (shimmed as `bin/cloud-debug`) takes `--resource-type` (default `cloud_run_revision`), so a future `gke-debug` / `functions-debug` can be grown thinly on top of the same engine without a rewrite. The digest step reuses the existing `agy-delegate.sh` — no new delegation logic was written.

## Safety

- **Read-only by default** — diagnosis + fix proposal only.
- **`--apply` is the only write path**, and it only ever lands the fix on a dedicated branch with the diff shown; nothing is deployed or merged automatically (a human reviews and merges).
- Uses the existing `gcloud` ADC — never asks for credentials/tokens.
- A missing `roles/logging.viewer` exits `3` with the exact `add-iam-policy-binding` command to fix it.

## What's in the diff

- `commands/cloud-run-debug.md` — the Conductor command (resolve scope → delegate digest → diagnose → optional `--apply` on a branch).
- `scripts/cloud-debug.sh` + `bin/cloud-debug` — the read-only engine and its PATH shim (issue #11 pattern).
- `scripts/doctor.sh` — health check now covers the new script + shim.
- `tests/run-tests.sh` — stubs `gcloud` + `agy`; covers fetch→digest, default `--since`, read-only (no files written / engine rejects `--apply`), permission-denied, no-logs, and missing-gcloud paths (+16 passing assertions).
- `README.md` / `CHANGELOG.md` / `plugin.json` (v0.15.0).

## Tests

`bash tests/run-tests.sh` → all new assertions pass. The one remaining `job cancel` failure is **pre-existing on `master`** (a sandbox limitation around killing a background process) and untouched by this change.

> **Draft on purpose — please review, do not auto-merge.** Out of scope by design (left to the adk-build side): deploy, eval, multi-service support.