### PR TITLE
release: 0.15.1 — recognize policy-context fix (#15) + harden regression guards

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.15.1
+- **Injected routing policy no longer references `$CLAUDE_PLUGIN_ROOT`**
+  ([#15](https://github.com/yuting0624/antigravity-for-claude-code/issues/15), fix by
+  **@Masterisk-F** in #16): the SessionStart `additionalContext` in
+  `hooks/policy-context.json` still told the model to run
+  `"$CLAUDE_PLUGIN_ROOT/scripts/agy-delegate.sh"` — but that variable isn't exported to
+  model-run Bash (same root cause as #11), so it expanded empty and the model had to
+  rediscover the `bin/` entrypoint. Now uses the bare `agy-delegate` bin name. (The #11
+  bin/ migration updated commands/skill/agents but missed this injected string.)
+  - This ships as a **version bump** so `/plugin marketplace update` recognizes the fix —
+    #16 landed on `master` without one, leaving installs on 0.15.0 unable to see it.
+- **Regression guard widened**: the contract test now also fails if any SessionStart
+  `additionalContext` references `$CLAUDE_PLUGIN_ROOT` (not just commands/skill markdown),
+  so this class of bug can't recur in injected context.
+- **Version-drift guard**: the contract test now asserts `SKILL.md`'s `version:` matches
+  `plugin.json` — they had drifted (skill stuck at 0.14.0 while the plugin was 0.15.0);
+  re-synced to 0.15.1.
+
 ## 0.15.0
 - **New command — `/antigravity:cloud-run-debug`** (Conductor/Executor demo): diagnose a failing
   Cloud Run service. agy (Gemini) does the bulk, cheap work — pulling `severity>=ERROR` logs via

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.14.0
+version: 0.15.1
 ---
 
 # Antigravity for Claude Code — hybrid SDLC

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -390,6 +390,14 @@ pj = json.load(open(p(".claude-plugin", "plugin.json")))
 need(pj.get("name") == "antigravity", "plugin.json name != antigravity")
 need(bool(pj.get("version")), "plugin.json missing version")
 
+# SKILL.md version frontmatter must track plugin.json (PR #14 drifted them: a version
+# bump that forgets the skill leaves stale docs and breaks update recognition reasoning)
+skill_txt = open(p("skills", "antigravity", "SKILL.md")).read()
+sm = re.search(r"(?m)^version:\s*(\S+)\s*$", skill_txt)
+need(bool(sm), "SKILL.md missing version frontmatter")
+if sm: need(sm.group(1) == pj.get("version"),
+            "SKILL.md version (%s) != plugin.json version (%s)" % (sm.group(1), pj.get("version")))
+
 mp = json.load(open(p(".claude-plugin", "marketplace.json")))
 plugins = mp.get("plugins", [])
 need(bool(plugins) and plugins[0].get("source") == "./", "marketplace plugins[0].source != ./")
@@ -432,6 +440,24 @@ for f in glob.glob(p("commands", "*.md")) + [p("skills", "antigravity", "SKILL.m
         t = open(f).read()
         need("CLAUDE_PLUGIN_ROOT}/scripts/" not in t and "CLAUDE_PLUGIN_ROOT/scripts/" not in t,
              "invokes $CLAUDE_PLUGIN_ROOT/scripts (empty on model Bash, issue #11): " + os.path.basename(f))
+
+# regression guard: any SessionStart `additionalContext` injected into the MODEL must not
+# reference $CLAUDE_PLUGIN_ROOT — it isn't exported to model-run Bash, so the model gets an
+# empty path and the instruction fails (issue #15). Structured hook *command* fields are
+# exempt (substitution works there) — only injected context strings are checked.
+def _ctx_strings(o):
+    if isinstance(o, dict):
+        for k, v in o.items():
+            if k == "additionalContext" and isinstance(v, str): yield v
+            else: yield from _ctx_strings(v)
+    elif isinstance(o, list):
+        for x in o: yield from _ctx_strings(x)
+for hf in glob.glob(p("hooks", "*.json")):
+    try: hd = json.load(open(hf))
+    except Exception: continue
+    for ac in _ctx_strings(hd):
+        need("CLAUDE_PLUGIN_ROOT" not in ac,
+             "injected additionalContext references $CLAUDE_PLUGIN_ROOT (empty on model Bash, issue #15): " + os.path.basename(hf))
 
 if errs:
     print("CONTRACT FAIL:")


### PR DESCRIPTION
Follow-up to #16 (@Masterisk-F's fix for #15). #16 was correct and is merged, but it landed on `master` **without a version bump**, so installs on 0.15.0 can't pick up the fix via `/plugin marketplace update`. This bumps to **0.15.1** and hardens the guards so this class of bug can't recur.

## Why a follow-up was needed
- **#16 shipped without a version bump.** Third-party marketplaces recognize updates by the `plugin.json` version string. master stayed `0.15.0`, so the policy-context fix wouldn't reach anyone already on 0.15.0. → bumped to `0.15.1`.
- **The #11 regression guard had a hole.** My #12 contract test only scanned `commands/*.md` + `SKILL.md` for `$CLAUDE_PLUGIN_ROOT/scripts` — it never checked the **injected** SessionStart `additionalContext`. That's exactly the gap that let #15 slip past the bin/ migration.
- **`SKILL.md` version had drifted.** PR #14 bumped `plugin.json` to 0.15.0 but left the skill frontmatter at 0.14.0.

## Changes
- **`plugin.json` `0.15.0` → `0.15.1`** so `/plugin marketplace update` recognizes #16's fix.
- **Contract test — injected-context guard:** fails if any SessionStart `additionalContext` references `$CLAUDE_PLUGIN_ROOT` (not exported to model-run Bash). Catches the #15 class in injected strings, not just markdown.
- **Contract test — version-sync guard:** asserts `SKILL.md` `version:` matches `plugin.json`. Re-synced the skill to `0.15.1`.
- **CHANGELOG** `0.15.1` entry (credits @Masterisk-F, #15).

## Verification
- Both new guards **negative-tested** — they fail on a reintroduced `$CLAUDE_PLUGIN_ROOT` ref and on a version mismatch, then pass once reverted.
- **91 tests pass** · `shellcheck` clean · `claude plugin validate` passes.

Closes #15.