### PR TITLE
release: 0.16.0 — digest enforcement, internal fan-out recipe + agy-trace, support docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"
@@ -59,6 +59,12 @@
       "type": "string",
       "title": "Model for the 'pro' tier",
       "description": "Override the exact agy model the 'pro' tier maps to (default: Gemini 3.1 Pro (High)). Use a name from `agy models`.",
+      "default": ""
+    },
+    "digest_warn_chars": {
+      "type": "string",
+      "title": "Digest-size warning threshold (chars)",
+      "description": "agy-delegate warns on stderr when a reply exceeds this many characters — a raw dump instead of the digest the cost discipline calls for. Empty = 8000. Set 0 to disable.",
       "default": ""
     }
   }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Something broken? The fields below let us diagnose in one round-trip.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! Every environment bug fixed so far (#6, #10, #11, #15) was
+        solved by exactly the info below. Please check
+        [docs/TROUBLESHOOTING.md](https://github.com/yuting0624/antigravity-for-claude-code/blob/master/docs/TROUBLESHOOTING.md)
+        first — your issue may already have a fix or a documented workaround.
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened, and what did you expect?
+      description: Include the exact command you ran (e.g. `/antigravity:delegate ...` or `agy-delegate ...`) and the output/error you got.
+      placeholder: |
+        Ran: /antigravity:delegate --tier pro "..."
+        Got: ...
+        Expected: ...
+    validations:
+      required: true
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Output of `agy-doctor` (or `/antigravity:setup`)
+      description: Paste the full output — it includes the plugin version, agy version/auth state, and platform checks. If `agy-doctor` isn't found, say so (that itself is diagnostic — likely a pre-0.14.0 install).
+      render: text
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / platform
+      placeholder: "macOS 15 · Ubuntu 24.04 · WSL2 (Ubuntu) · Windows 11 (Git Bash)"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How is the plugin installed?
+      description: Marketplace and local-dev installs resolve paths differently (see #11) — this matters.
+      options:
+        - Marketplace (/plugin install antigravity@antigravity-for-claude-code)
+        - Local dev (claude --plugin-dir ...)
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: agyver
+    attributes:
+      label: agy CLI version
+      placeholder: "agy --version → 1.0.12 (also visible in doctor output)"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 Troubleshooting guide
+    url: https://github.com/yuting0624/antigravity-for-claude-code/blob/master/docs/TROUBLESHOOTING.md
+    about: Windows/WSL problems, writes that silently don't happen, quota/auth/timeout exit codes — check here first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Propose an improvement or new capability.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: The pain first, not the mechanism — what goes wrong or costs too much today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see. A rough sketch is fine; PRs are welcome too (see CONTRIBUTING.md).
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Including "do it manually today via ..." if that's a thing.
+    validations:
+      required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
 ## 0.16.0
+- **Internal fan-out recipe + `agy-trace`** (community pointer to upstream
+  antigravity-cli#105; **verified headless on agy 1.0.12**): agy's `invoke_subagent`
+  sandbox only allows TypeNames `self`/`research` — custom TypeNames are rejected. The
+  skill now documents the **role-delegation pattern** (TypeName `self` + a specialist
+  `Role`) for one-delegation internal fan-out, so coordination tokens land on the cheap
+  (Gemini) side instead of the frontier side. Spawning needs no `--yolo` (writes inside
+  the work still do).
+  - Each spawned subagent leaves a **readable step-by-step `transcript.jsonl`** under
+    `~/.gemini/antigravity-cli/brain/<conversationId>/` — unlike the opaque conversation
+    `.db` blobs. New **`agy-trace`** (script + bin shim) pretty-prints one (`agy-trace
+    <conversationId>`), lists recent ones (`--list`), or emits raw JSONL (`--raw`) so
+    Claude can run a real trajectory audit on what subagents actually did.
+  - Skill's trajectory-check gate updated accordingly; `doctor` covers the new script/shim.
 - **`--digest` flag + digest-size guard** — the cost discipline's biggest lever ("ingest
   digests, not dumps") is now enforced in code, not just prose
   ([#5](https://github.com/yuting0624/antigravity-for-claude-code/issues/5)):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.16.0
+- **`--digest` flag + digest-size guard** — the cost discipline's biggest lever ("ingest
+  digests, not dumps") is now enforced in code, not just prose
+  ([#5](https://github.com/yuting0624/antigravity-for-claude-code/issues/5)):
+  - `agy-delegate --digest` appends a digest-only **output contract** to the prompt
+    (compact bullets + a one-line `DIGEST:` trailer; no full files / raw logs).
+  - The wrapper now **warns on stderr when a reply comes back dump-sized** (default
+    threshold 8000 chars) so the conductor doesn't silently ingest a raw dump. New plugin
+    option `digest_warn_chars` tunes it (`0` disables).
+  - `delegate` command + skill updated to use `--digest` for bulk reads and to not ingest
+    a flagged dump.
+- **Support docs — one-round-trip diagnosis**: every environment bug so far (#6, #10,
+  #11, #15) needed the same three facts, so they're now asked up front:
+  - **Issue templates** (`.github/ISSUE_TEMPLATE/`): the bug form requires `agy-doctor`
+    output, OS/platform, and install method (marketplace vs `--plugin-dir`).
+  - **`docs/TROUBLESHOOTING.md`**: symptom-first fixes — Windows headless hang (and the
+    "agy works when I type it" console explanation), WSL `/mnt` slowness, silent
+    no-write without `--yolo`, exit-code/`AGY_SIGNAL` table, tier remaps, updating.
+
 ## 0.15.1
 - **Injected routing policy no longer references `$CLAUDE_PLUGIN_ROOT`**
   ([#15](https://github.com/yuting0624/antigravity-for-claude-code/issues/15), fix by

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ you → Claude Code (conduct: design / verify / review)
 - **Adds tools Claude lacks natively** — live **Google/web search**, **Vertex AI Search** over your internal data, deep research, Cloud Logging. Claude reviews and re-checks the results.
 - **Cross-model verification** — an independent, different-model opinion on your code.
 - **Background jobs** — fire a long delegation, keep working, collect later.
+- **Internal fan-out** — one delegation, and agy spawns role-assigned subagents on the cheap side (`TypeName "self"` + Role); each leaves a **readable trajectory** you audit with `agy-trace`.
 - **Built-in cost discipline** — measured, not guessed (see below).
 - **Drops in with the discipline on** — a `SessionStart` hook injects the *cost-aware*
   routing policy automatically (toggle in plugin settings), and the `antigravity-delegate`
@@ -174,7 +175,7 @@ skills/antigravity/SKILL.md   WHEN + HOW Claude collaborates with agy
 agents/           antigravity-delegate subagent (file work runs on Gemini, not Claude)
 commands/         slash commands (delegate, review, research, cloud-run-debug, setup, status, result, cancel)
 hooks/            SessionStart: agy health check + auto-inject the cost-aware policy
-scripts/          agy-delegate · agy-job · agy-cost-compare · cloud-debug · measure-session · doctor
+scripts/          agy-delegate · agy-job · agy-cost-compare · cloud-debug · agy-trace · measure-session · doctor
 docs/             AB-RESULTS (measured A/B) · TROUBLESHOOTING · DEMO-KIT
 prices.json       Vertex rate config (verify before quoting)
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ scripts/agy-delegate.sh --tier flash "Summarize this changelog in 3 bullets: ...
 # give Antigravity a workspace for multi-file agentic work
 scripts/agy-delegate.sh --tier pro --dir ./src "List every TODO with file:line"
 
+# bulk read -> digest-only reply (the biggest cost lever; wrapper warns on dump-sized replies)
+scripts/agy-delegate.sh --digest --dir . "Map the auth flow end to end"
+
 # live web / Google search (tools need --yolo in headless mode)
 scripts/agy-delegate.sh --tier pro --yolo "Web-search <X>. Give URLs + dates."
 
@@ -135,7 +138,7 @@ conductor — that's what gives both the cost saving and the cross-model verific
 Delegation doesn't save money by itself — these do (also in the skill):
 
 1. **Delegate above the break-even** — bulk/parallel/repetitive work, not tiny tasks.
-2. **Keep Claude's context lean** — don't re-read what agy already handled; take a **digest**, not raw output. (Biggest lever — it collapses `cache_read`.)
+2. **Keep Claude's context lean** — don't re-read what agy already handled; take a **digest**, not raw output. (Biggest lever — it collapses `cache_read`.) Enforced in code: `--digest` appends a digest-only output contract, and the wrapper **warns when a reply comes back dump-sized** (tune via the `digest_warn_chars` plugin option).
 3. **Batch** — one big delegation beats many round-trips.
 4. **Review the diff, not the whole tree.**
 
@@ -145,6 +148,8 @@ Delegation doesn't save money by itself — these do (also in the skill):
 
 <details>
 <summary><b>🚧 Guardrails &amp; known limits</b></summary>
+
+> **Something broken?** See **[docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** — symptom-first fixes for Windows/WSL, writes that silently don't happen, quota/auth/timeout codes, and updating.
 
 **Guardrails**
 - Always **verify** agy's output (it can be wrong, and may even alter its environment to make a check pass — re-run gates yourself in a clean state).
@@ -170,7 +175,7 @@ agents/           antigravity-delegate subagent (file work runs on Gemini, not C
 commands/         slash commands (delegate, review, research, cloud-run-debug, setup, status, result, cancel)
 hooks/            SessionStart: agy health check + auto-inject the cost-aware policy
 scripts/          agy-delegate · agy-job · agy-cost-compare · cloud-debug · measure-session · doctor
-docs/             AB-RESULTS (measured A/B) · DEMO-KIT
+docs/             AB-RESULTS (measured A/B) · TROUBLESHOOTING · DEMO-KIT
 prices.json       Vertex rate config (verify before quoting)
 ```
 

--- a/bin/agy-trace
+++ b/bin/agy-trace
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# bin/ entrypoint on the Bash-tool PATH (Claude Code adds a plugin's bin/ to PATH).
+# $CLAUDE_PLUGIN_ROOT is NOT exported to model-run Bash (issue #11), so commands and
+# skills invoke this bare name; it forwards to the implementation in ../scripts/agy-trace.sh.
+exec "$(cd "$(dirname "$0")/.." && pwd)/scripts/agy-trace.sh" "$@"

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -18,9 +18,13 @@ Do this:
    `--yolo` (`--dangerously-skip-permissions`) — approve it when asked, or pre-allow it in
    settings; non-interactive (`claude -p`) without that permission can't write via agy.
 2. Run **synchronously** (you may be headless — do not background-and-wait):
-   `agy-delegate --tier <tier> [--dir .] [--yolo] "<task>"`
+   `agy-delegate --tier <tier> [--dir .] [--yolo] [--digest] "<task>"`
+   For read/analysis tasks, add `--digest` — it appends a digest-only output contract so
+   agy returns compact bullets instead of raw content.
 3. Ingest only the **result/digest** — do NOT re-read the files agy already handled
-   (keeps your context lean; that's where the cost savings come from).
+   (keeps your context lean; that's where the cost savings come from). If the wrapper
+   prints a *"looks like a raw dump"* note on stderr, do NOT ingest the raw output —
+   re-run with `--digest` or ask agy to summarize it first.
 4. **Verify**: actually run/check the output; never trust a self-reported "done".
    Report what you delegated and how you verified it.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,137 @@
+# Troubleshooting
+
+Symptom-first guide to every problem reported so far. **Start by running `agy-doctor`**
+(or `/antigravity:setup` inside Claude Code) — it diagnoses most of the below and prints
+the plugin version, agy version/auth state, and platform warnings.
+
+---
+
+## "`/scripts/agy-delegate.sh: No such file or directory`" or `$CLAUDE_PLUGIN_ROOT` is empty
+
+**Cause:** you're on a plugin version < 0.14.0. `$CLAUDE_PLUGIN_ROOT` is only substituted
+inside structured config (hooks/MCP) — it is **not** exported to the shell commands the
+model runs, so marketplace installs saw an empty path ([#11](https://github.com/yuting0624/antigravity-for-claude-code/issues/11),
+[#15](https://github.com/yuting0624/antigravity-for-claude-code/issues/15)).
+
+**Fix:** update — since 0.14.0 everything is invoked by bare names (`agy-delegate`,
+`agy-job`, `agy-doctor`, `agy-cost-compare`) on the plugin's `bin/` PATH:
+
+```
+/plugin marketplace update antigravity-for-claude-code
+/reload-plugins
+```
+
+---
+
+## Windows: delegation hangs, or exits 12 (TIMEOUT) with a 0-byte log
+
+**Cause (upstream, not the plugin):** on native Windows, headless `agy` needs a real
+console (ConPTY). When the plugin runs it as a child process with redirected stdio there
+is no console, and agy v1.0.x can hard-hang before producing any output
+([#6](https://github.com/yuting0624/antigravity-for-claude-code/issues/6)).
+
+**"But agy works when I type it in my terminal!"** — yes: typed directly, agy has a real
+console (interactive mode). Invoked by the plugin, it runs headless (no console). That's
+the difference, not Windows vs the plugin.
+
+What the plugin does about it: a wall-clock guard (`timeout`/`gtimeout`) turns the hang
+into a clean **TIMEOUT (exit 12)** instead of a freeze, and `agy-doctor` reports "headless
+hang" instead of the misleading "not authenticated".
+
+**Fix: use WSL** (fully supported):
+1. `wsl --install` (one-time; reboot)
+2. Install Claude Code **and** the Antigravity CLI *inside* WSL; authenticate agy there
+   (`agy models` should list models)
+3. Keep your repo on the WSL Linux filesystem (`~/project`), **not** `/mnt/c/...`
+4. Run `/antigravity:setup` from WSL — it should go green
+
+---
+
+## WSL: delegation works but is absurdly slow (20s+ for trivial calls)
+
+**Cause:** your repo lives on a Windows mount (`/mnt/c/...`). agy reads `--dir` workspaces
+over WSL's 9p bridge, which is ~10x slower than native FS.
+
+**Fix:** move the repo into the WSL Linux filesystem (e.g. `~/projects/...`). Both the
+wrapper and `agy-doctor` warn when they detect this.
+
+---
+
+## agy says "done" but wrote no files
+
+**Cause:** write tasks need `--yolo` (`--dangerously-skip-permissions`). Without it,
+headless agy only *describes* the edits and still returns success
+([#10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)). The wrapper
+warns when a write-looking prompt lacks `--yolo`.
+
+**Fix:**
+- Pass `--yolo` for write tasks, and run them on a **dedicated branch** (add `--sandbox`
+  for containment).
+- Claude Code may prompt for (or in auto-mode, block) `--dangerously-skip-permissions` —
+  approve it, or pre-allow `Bash(agy-delegate*)` in your permission settings.
+- **Always verify files actually changed** (`git status`) — never trust the self-report.
+- Long write tasks can exceed Claude Code's ~2-min synchronous Bash limit → run them as a
+  background job: `ID=$(agy-job start --tier pro --dir . "<task>")`, then
+  `/antigravity:status` / `/antigravity:result <id>` (interactive sessions only).
+
+---
+
+## Exit codes & `AGY_SIGNAL`
+
+On classifiable failures the wrapper prints a machine-readable line to stderr:
+`AGY_SIGNAL {"status":"...","reason":"...","model":"...","retry":"..."}`
+
+| exit | meaning | what to do |
+|---|---|---|
+| 0 | success | — |
+| 1 | usage error | check flags (`agy-delegate --help`) |
+| 2 | agy failed (unclassified) | read the stderr it relayed |
+| 3 | agy returned empty output | retry; check model availability (`agy models`) |
+| 10 | quota / rate limit | wait, then resume the same conversation with `--continue` |
+| 11 | not authenticated | run `agy` once interactively to sign in |
+| 12 | timeout (agy's own, or the wall-clock guard) | raise `--timeout`, narrow the task; on Windows see the hang section above |
+| 13 | agy not on PATH | install the Antigravity CLI |
+
+---
+
+## "tier model not in `agy models`" warning from doctor
+
+**Cause:** agy's model list is plan-dependent (Vertex plans are Gemini-only; some plans
+expose Claude/GPT). The default tier mappings may not match your plan.
+
+**Fix:** remap tiers to models you actually have — plugin options `tier_flash` /
+`tier_flash_lo` / `tier_pro` or `default_model` (exact names from `agy models`), or pass
+`--model "<exact name>"` per call.
+
+---
+
+## Output is huge / "looks like a raw dump, not a digest"
+
+**Cause:** the wrapper warns (stderr) when a reply exceeds `digest_warn_chars` (default
+8000). Ingesting raw dumps into the conductor's context is where the cost savings die.
+
+**Fix:** re-run with `--digest` (appends a digest-only output contract to the prompt), or
+have agy summarize before you ingest. Tune the threshold via the `digest_warn_chars`
+plugin option; `0` disables the warning.
+
+---
+
+## Updating / checking your version
+
+Third-party marketplace plugins do **not** auto-update by default:
+
+```
+/plugin marketplace update antigravity-for-claude-code
+/reload-plugins
+```
+
+`agy-doctor` prints the installed plugin version (last line of its checks). Fixes land as
+version bumps — see [CHANGELOG.md](../CHANGELOG.md).
+
+---
+
+## Still stuck?
+
+[Open a bug report](https://github.com/yuting0624/antigravity-for-claude-code/issues/new/choose)
+— the template asks for your `agy-doctor` output, OS, and install method, which is
+usually everything needed to diagnose in one round-trip.

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -25,6 +25,8 @@
 #       --timeout <dur>              Print-mode timeout, e.g. 10m (default: 5m)
 #       --yolo                       Auto-approve all tool permissions (DANGEROUS)
 #       --sandbox                    Run agent with terminal sandbox restrictions
+#       --digest                     Append a digest-only output contract to the prompt
+#                                    (ingest digests, not raw dumps — the biggest cost lever)
 #   -c, --continue                   Resume the most recent agy conversation (stateful)
 #       --conversation <id>          Resume a specific agy conversation by ID (stateful)
 #   -m, --model <exact name>         Use an exact agy model (any from `agy models`: Gemini/Claude/GPT…)
@@ -50,6 +52,7 @@ TIER_EXPLICIT=0
 MODEL=""
 YOLO=0
 SANDBOX=0
+DIGEST=0
 ADD_DIRS=()
 PROMPT=""
 CONTINUE=0
@@ -138,6 +141,7 @@ while [ $# -gt 0 ]; do
     --timeout)      need "$#" "$1"; TIMEOUT="$2"; shift 2 ;;
     --yolo)         YOLO=1; shift ;;
     --sandbox)      SANDBOX=1; shift ;;
+    --digest)       DIGEST=1; shift ;;               # ask agy for a digest-only reply
     -c|--continue)  CONTINUE=1; shift ;;            # resume most recent agy conversation
     --conversation) need "$#" "$1"; CONV_ID="$2"; shift 2 ;; # resume a specific conversation by ID
     -m|--model)     need "$#" "$1"; MODEL="$2"; shift 2 ;;
@@ -198,6 +202,16 @@ if [ "$YOLO" -eq 0 ] && [ "$PRINT_CMD" -ne 1 ]; then
       echo "agy-delegate: note: this looks like a write task but --yolo is not set — without it agy only DESCRIBES edits and writes nothing (still returns success). Add --yolo (and run on a branch) to actually write files." >&2 ;;
   esac
   shopt -u nocasematch
+fi
+
+# --digest: append an explicit output contract so agy returns a compact digest
+# instead of raw content. Ingesting digests (never dumps) is the plugin's single
+# biggest cost lever — it keeps the conductor's context lean (issue #5).
+# (Appended AFTER the write-task heuristic so that scans the user's prompt only.)
+if [ "$DIGEST" -eq 1 ]; then
+  PROMPT="$PROMPT
+
+OUTPUT CONTRACT (digest): reply with ONLY a compact digest — short bullets (findings / decisions / errors, with file:line references where useful). NO full file contents, NO raw logs, NO long code blocks. End with exactly one line: DIGEST: <one-sentence summary>."
 fi
 
 # --- assemble agy args ---
@@ -283,6 +297,16 @@ fi
 if [ -z "${OUT//[$' \t\n\r']/}" ]; then
   echo "agy-delegate: agy returned empty output (model='$MODEL')" >&2
   exit 3
+fi
+
+# Digest-size guard: the cost saving depends on the conductor ingesting a DIGEST,
+# not a raw dump — if the reply is dump-sized, say so on stderr (advisory only;
+# stdout passes through untouched). Tune via the digest_warn_chars plugin option
+# (env CLAUDE_PLUGIN_OPTION_DIGEST_WARN_CHARS; empty = 8000, 0 = off).
+WARN_CHARS="${CLAUDE_PLUGIN_OPTION_DIGEST_WARN_CHARS:-8000}"
+case "$WARN_CHARS" in (*[!0-9]*|'') WARN_CHARS=8000 ;; esac
+if [ "$WARN_CHARS" -gt 0 ] && [ "${#OUT}" -gt "$WARN_CHARS" ]; then
+  echo "agy-delegate: note: output is ${#OUT} chars (> ${WARN_CHARS}) — that looks like a raw dump, not a digest. Don't ingest this into the conductor's context: re-run with --digest, or have agy summarize it first. (plugin option digest_warn_chars tunes this; 0 disables.)" >&2
 fi
 
 printf '%s\n' "$OUT"

--- a/scripts/agy-trace.sh
+++ b/scripts/agy-trace.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# agy-trace.sh — read an agy SUBAGENT trajectory (transcript.jsonl).
+# Part of the "Antigravity for Claude Code" plugin.
+#
+# When agy spawns internal subagents (invoke_subagent with TypeName "self" + a
+# Role — see the skill's "Internal fan-out" recipe), each spawn's tool result
+# includes a logAbsoluteUri pointing at a READABLE step-by-step JSONL transcript:
+#   ~/.gemini/antigravity-cli/brain/<conversationId>/.system_generated/logs/transcript.jsonl
+# Unlike the opaque conversation .db blobs, these are auditable — this tool
+# pretty-prints them so Claude can run a trajectory check on what a subagent
+# actually did (verified on agy 1.0.12).
+#
+# Usage:
+#   agy-trace.sh <conversationId | path/to/transcript.jsonl>   Pretty-print the steps
+#   agy-trace.sh --raw <conversationId | path>                 Raw JSONL (pipe to jq etc.)
+#   agy-trace.sh --list [N]                                    N most recent transcripts (default 10)
+#   agy-trace.sh -h | --help
+#
+# Exit codes: 0 ok | 1 usage | 2 transcript not found
+#
+set -euo pipefail
+
+# Override for tests; real location is agy's brain dir.
+BRAIN="${AGY_BRAIN_DIR:-$HOME/.gemini/antigravity-cli/brain}"
+
+die()   { echo "agy-trace: $*" >&2; exit 1; }
+usage() { sed -n '/^# Usage:/,/^# Exit codes:/p' "$0" | sed 's/^# \{0,1\}//'; exit 0; }
+
+# Resolve an argument (conversationId or literal path) to a transcript file.
+resolve() {
+  local a="$1"
+  if [ -f "$a" ]; then printf '%s\n' "$a"; return 0; fi
+  local t="$BRAIN/$a/.system_generated/logs/transcript.jsonl"
+  if [ -f "$t" ]; then printf '%s\n' "$t"; return 0; fi
+  echo "agy-trace: no transcript for '$a' (looked for a file, then $t)" >&2
+  echo "agy-trace: hint: 'agy-trace --list' shows recent subagent transcripts" >&2
+  exit 2
+}
+
+list_recent() {
+  local n="${1:-10}"
+  case "$n" in (*[!0-9]*|'') n=10 ;; esac
+  local found=0 f id when steps
+  # newest first; glob may match nothing -> nullglob-like guard via -f check
+  # shellcheck disable=SC2012
+  for f in $(ls -t "$BRAIN"/*/.system_generated/logs/transcript.jsonl 2>/dev/null | head -"$n"); do
+    [ -f "$f" ] || continue
+    found=1
+    id="${f#"$BRAIN"/}"; id="${id%%/*}"
+    steps="$(wc -l < "$f" | tr -d ' ')"
+    when="$(date -r "$f" '+%Y-%m-%d %H:%M' 2>/dev/null || echo '?')"
+    printf '%s  %s  %s steps\n' "$when" "$id" "$steps"
+  done
+  if [ "$found" -eq 0 ]; then
+    echo "agy-trace: no subagent transcripts under $BRAIN" >&2
+    echo "agy-trace: (they appear after agy spawns internal subagents — see the skill's Internal fan-out recipe)" >&2
+    exit 2
+  fi
+}
+
+pretty() { # $1 = transcript path
+  echo "# $1"
+  python3 - "$1" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path, encoding="utf-8", errors="replace") as fh:
+    for i, line in enumerate(fh):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except ValueError:
+            print(f"[{i}] (unparseable line)")
+            continue
+        content = str(d.get("content") or "").replace("\n", " ")
+        if len(content) > 160:
+            content = content[:160] + "…"
+        print(f"[{d.get('step_index', i)}] {str(d.get('type','?')):<28} {str(d.get('status','?')):<6} {content}")
+PY
+}
+
+[ $# -ge 1 ] || die "no argument (pass a conversationId, a transcript path, or --list; -h for help)"
+case "$1" in
+  -h|--help) usage ;;
+  --list)    shift; list_recent "${1:-10}" ;;
+  --raw)     shift; [ $# -ge 1 ] || die "--raw needs a conversationId or path"
+             # resolve in an assignment so its exit code (2 = not found) propagates
+             # instead of being swallowed by a command-substitution subshell.
+             T="$(resolve "$1")" || exit $?
+             cat "$T" ;;
+  -*)        die "unknown option '$1'" ;;
+  *)         T="$(resolve "$1")" || exit $?
+             pretty "$T" ;;
+esac

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -107,7 +107,7 @@ else
 fi
 
 # 4. plugin scripts executable
-for s in agy-delegate.sh agy-cost-compare.sh cloud-debug.sh; do
+for s in agy-delegate.sh agy-cost-compare.sh cloud-debug.sh agy-trace.sh; do
   if [ -x "$HERE/$s" ]; then ok "$s executable"; else
     bad "$s not executable"; info "fix: chmod +x \"$HERE/$s\""
   fi
@@ -122,7 +122,7 @@ done
 
 # 4b2. bin/ entrypoints executable (added to the Bash-tool PATH; commands/skills call
 #      these bare names — $CLAUDE_PLUGIN_ROOT is not exported to model-run Bash, issue #11)
-for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug; do
+for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug agy-trace; do
   if [ -x "$ROOT/bin/$b" ]; then ok "bin/$b executable"; else
     bad "bin/$b not executable"; info "fix: chmod +x \"$ROOT/bin/$b\""
   fi

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -114,7 +114,11 @@ Claude owns correctness. For anything that ships:
    final text. The per-conversation logs under `~/.gemini/antigravity-cli/conversations`
    are **SQLite `.db` files with opaque blob columns, not human-readable** — don't rely
    on reading them. Instead, have agy **summarize its own steps** as part of its output,
-   or keep a session with `--continue`/`--conversation` and ask it to recap.)
+   or keep a session with `--continue`/`--conversation` and ask it to recap.
+   **Exception — internal fan-out:** each spawned subagent leaves a READABLE
+   step-by-step `transcript.jsonl` under `~/.gemini/antigravity-cli/brain/<conversationId>/`;
+   audit it with `agy-trace <conversationId>` (or `agy-trace --list`). See the
+   Internal fan-out recipe below.)
 4. **Review every shipping line** — be skeptical of clever code; check imports are real
    packages (hallucinated deps), error handling, edge cases, and that the contract
    itself is internally consistent (examples/placeholders match the verified behavior).
@@ -216,6 +220,43 @@ ROOT=agy-delegate
 "$ROOT" --tier pro --yolo "List Vertex AI Search engines (list_engines)."
 "$ROOT" --tier pro --yolo "Search engine <ENGINE_ID> for: <question>. Cite the hits."
 ```
+
+## Internal fan-out recipe (agy spawns its own subagents)
+
+agy has a built-in `invoke_subagent` tool, but its sandbox only allows the pre-approved
+TypeNames **`self`** and **`research`** — a custom TypeName is rejected with
+`CORTEX_STEP_TYPE_INVOKE_SUBAGENT: ... not found or not allowed to be invoked`, even if
+it appears in `/agents` (upstream issue antigravity-cli#105). The working pattern
+(**verified headless on agy 1.0.12**) is **role delegation**: invoke TypeName `self` and
+inject the specialty via `Role` + `Prompt`.
+
+Use it for **orchestrator-mode work pushed down a level**: instead of Claude dispatching
+N parallel `agy-job` runs (N round-trips, coordination spend on the frontier side), send
+ONE delegation and let agy fan out internally — the coordination tokens land on the
+cheap side, and you ingest a single digest.
+
+```bash
+agy-delegate --dir . --digest --timeout 10m \
+  "Decompose <task> into up to 3 units. For each unit, invoke a background subagent
+   with TypeName \"self\" and a specialist Role (e.g. 'Test Writer'), each following
+   AGENTS.md. Wait for all of them, then report per-unit results, each subagent's
+   conversationId, and end with a DIGEST line."
+```
+
+Verified behaviors (agy 1.0.12):
+- **Spawning needs no `--yolo`** — subagent invocation isn't permission-gated; file
+  writes / web tools *inside* the subagents' work still need it.
+- Each spawn's tool result includes a `logAbsoluteUri` → a **readable step-by-step
+  `transcript.jsonl`** under `~/.gemini/antigravity-cli/brain/<conversationId>/` —
+  *better* trajectory visibility than a plain delegation. Have the parent report each
+  `conversationId`, then audit with `agy-trace <id>` (`agy-trace --list` finds recent ones).
+- Spawns are real and observable (new conversation threads appear) — but still run the
+  verification gates on the merged result; more autonomy = more surface for error.
+
+Caveats: `self`+Role is a **workaround around the sandbox allowlist**, not a documented
+contract — re-verify after agy upgrades. Bound the fan-out width in the prompt (agy
+chooses parallelism otherwise). A wide fan-out takes longer wall-clock — raise
+`--timeout`, and in an interactive session prefer a background job (`agy-job`).
 
 ## Deep-research recipe (multi-source)
 

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.15.1
+version: 0.16.0
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -62,8 +62,11 @@ agy-delegate [options] "the task prompt"
 ```
 Options: `--tier flash|flash-lo|pro` · `--dir <path>` (workspace, repeatable) ·
 `--timeout 10m` · `--yolo` (auto-approve tools — needed for any tool use in headless
-mode) · `--sandbox` · `--print-command` (dry run: show the resolved `agy` call, don't run
-it) · pipe a long prompt with a trailing `-`.
+mode) · `--sandbox` · `--digest` (append a digest-only output contract — use it for any
+bulk read/analysis; the wrapper also warns on stderr when a reply comes back dump-sized,
+because ingesting digests instead of dumps is the single biggest cost lever) ·
+`--print-command` (dry run: show the resolved `agy` call, don't run it) · pipe a long
+prompt with a trailing `-`.
 
 The wrapper handles agy's quirks (prompt is the value of `-p`; non-TTY stdout drop via
 `< /dev/null`; no `--output-format json`, so output is plain text you parse).

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -328,7 +328,7 @@ else echo "FAIL: delegate agent missing PreToolUse gate"; FAIL=$((FAIL+1)); fi
 
 echo "== bin/ entrypoints (issue #11: \$CLAUDE_PLUGIN_ROOT not on model-run Bash) =="
 BIN="$ROOT/bin"
-for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug; do
+for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug agy-trace; do
   if [ -x "$BIN/$b" ]; then echo "ok: bin/$b executable"; PASS=$((PASS+1));
   else echo "FAIL: bin/$b missing or not executable"; FAIL=$((FAIL+1)); fi
 done
@@ -340,6 +340,29 @@ case "$out" in *doctor*) echo "ok: bin/agy-doctor forwards to doctor.sh"; PASS=$
   *) echo "FAIL: bin/agy-doctor did not forward (got: '$out')"; FAIL=$((FAIL+1));; esac
 out=$(env -u CLAUDE_PLUGIN_ROOT "$BIN/cloud-debug" --service svc --print-command 2>/dev/null); rc=$?
 check "bin/cloud-debug forwards to cloud-debug.sh (no CLAUDE_PLUGIN_ROOT)" 0 "$rc" "logging read" "$out"
+
+echo "== agy-trace.sh (subagent trajectory reader) =="
+TRACE="$ROOT/scripts/agy-trace.sh"
+# fixture: a brain dir with one subagent transcript (shape matches agy 1.0.12)
+FIXBRAIN="$TMP/brain"
+mkdir -p "$FIXBRAIN/conv-123/.system_generated/logs"
+cat > "$FIXBRAIN/conv-123/.system_generated/logs/transcript.jsonl" <<'JSONL'
+{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>do the thing</USER_REQUEST>"}
+{"step_index":1,"source":"SYSTEM","type":"PLANNER_RESPONSE","status":"DONE","content":"I did the thing and reported back."}
+JSONL
+out=$(AGY_BRAIN_DIR="$FIXBRAIN" "$TRACE" conv-123 2>&1); rc=$?
+check "trace by conversationId -> pretty steps" 0 "$rc" "USER_INPUT" "$out"
+check "trace shows planner step" 0 "$rc" "PLANNER_RESPONSE" "$out"
+out=$("$TRACE" "$FIXBRAIN/conv-123/.system_generated/logs/transcript.jsonl" 2>&1); rc=$?
+check "trace by literal path works" 0 "$rc" "USER_INPUT" "$out"
+out=$(AGY_BRAIN_DIR="$FIXBRAIN" "$TRACE" --raw conv-123 2>&1); rc=$?
+check "--raw emits raw JSONL" 0 "$rc" '"step_index":0' "$out"
+out=$(AGY_BRAIN_DIR="$FIXBRAIN" "$TRACE" --list 2>&1); rc=$?
+check "--list shows the transcript" 0 "$rc" "conv-123" "$out"
+out=$(AGY_BRAIN_DIR="$FIXBRAIN" "$TRACE" no-such-conv 2>&1); rc=$?
+check "unknown conversationId -> exit 2" 2 "$rc" "no transcript" "$out"
+out=$(env -u CLAUDE_PLUGIN_ROOT AGY_BRAIN_DIR="$FIXBRAIN" "$BIN/agy-trace" conv-123 2>&1); rc=$?
+check "bin/agy-trace forwards (no CLAUDE_PLUGIN_ROOT)" 0 "$rc" "USER_INPUT" "$out"
 
 echo "== measure-session.py =="
 SESS="$TMP/sess.jsonl"
@@ -449,7 +472,7 @@ for s in ("hooks/check-agy.sh", "hooks/inject-policy.sh", "hooks/validate-delega
 
 # bin/ entrypoints exist + executable (issue #11: $CLAUDE_PLUGIN_ROOT isn't exported
 # to model-run Bash, so commands/skill must call these bare names on the PATH)
-for b in ("agy-delegate", "agy-job", "agy-cost-compare", "agy-doctor", "cloud-debug"):
+for b in ("agy-delegate", "agy-job", "agy-cost-compare", "agy-doctor", "cloud-debug", "agy-trace"):
     need(os.access(p("bin", b), os.X_OK), "bin entrypoint missing/not executable: bin/" + b)
 
 # regression guard: commands & skill must NOT invoke $CLAUDE_PLUGIN_ROOT/scripts/* — that

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -26,6 +26,7 @@ case "${STUB_MODE:-text}" in
   quota)   echo "Error: quota exceeded for this model" >&2; exit 1 ;;     # -> wrapper exit 10
   auth)    echo "Error: request is unauthenticated; please sign in" >&2; exit 1 ;; # -> exit 11
   timeout) echo "Error: deadline exceeded (the request timed out)" >&2; exit 1 ;;  # -> exit 12
+  big)     printf 'x%.0s' $(seq 1 20000); echo ;;    # dump-sized reply -> digest guard warns
   *)       echo "STUB_OK" ;;
 esac
 STUB
@@ -169,6 +170,24 @@ else echo "ok: no write-warning when --yolo is set"; PASS=$((PASS+1)); fi
 out=$(STUB_MODE=args "$DELEGATE" "summarize the changelog in 3 bullets" 2>&1); rc=$?
 if printf '%s' "$out" | grep -q "DESCRIBES"; then echo "FAIL: warned for a non-write prompt"; FAIL=$((FAIL+1));
 else echo "ok: no write-warning for a read/summary prompt"; PASS=$((PASS+1)); fi
+
+# --digest appends the digest-only output contract to the prompt (issue #5)
+out=$(STUB_MODE=args "$DELEGATE" --digest "hi" 2>/dev/null); rc=$?
+check "--digest appends the output contract" 0 "$rc" "OUTPUT CONTRACT (digest)" "$out"
+out=$("$DELEGATE" --help); rc=$?
+check "usage documents --digest" 0 "$rc" "--digest" "$out"
+
+# digest-size guard: dump-sized reply -> stderr note; small reply -> silent; 0 disables
+out=$(STUB_MODE=big "$DELEGATE" "hi" 2>&1 >/dev/null); rc=$?
+check "dump-sized output -> raw-dump note on stderr" 0 "$rc" "raw dump" "$out"
+out=$(STUB_MODE=text "$DELEGATE" "hi" 2>&1 >/dev/null)
+if printf '%s' "$out" | grep -q "raw dump"; then echo "FAIL: digest guard fired on a small reply"; FAIL=$((FAIL+1));
+else echo "ok: digest guard silent on a small reply"; PASS=$((PASS+1)); fi
+out=$(STUB_MODE=big CLAUDE_PLUGIN_OPTION_DIGEST_WARN_CHARS=0 "$DELEGATE" "hi" 2>&1 >/dev/null)
+if printf '%s' "$out" | grep -q "raw dump"; then echo "FAIL: digest guard fired with digest_warn_chars=0"; FAIL=$((FAIL+1));
+else echo "ok: digest_warn_chars=0 disables the guard"; PASS=$((PASS+1)); fi
+out=$(STUB_MODE=text CLAUDE_PLUGIN_OPTION_DIGEST_WARN_CHARS=5 "$DELEGATE" "hi" 2>&1 >/dev/null); rc=$?
+check "custom digest_warn_chars threshold respected" 0 "$rc" "raw dump" "$out"
 
 # WSL slow-mount note: fires only under WSL AND when --add-dir is on /mnt/*
 out=$(WSL_DISTRO_NAME=Ubuntu "$DELEGATE" --dir /mnt/c/proj --print-command "hi" 2>&1); rc=$?


### PR DESCRIPTION
The 0.16.0 release — the cost lever moves from prose to code, agy's internal fan-out becomes a first-class (and auditable) pattern, and bug reports become one-round-trip.

Closes #5.

## 1. `--digest` flag + digest-size guard (closes #5)

The cost discipline's biggest measured lever is "ingest digests, not dumps" — until now it was only prose in the skill.

- **`agy-delegate --digest`** appends a digest-only **output contract** to the prompt (compact bullets + one-line `DIGEST:` trailer; no full files / raw logs / long code blocks).
- The wrapper now **warns on stderr when a reply comes back dump-sized** (default 8000 chars) so the conductor doesn't silently ingest a raw dump. New plugin option **`digest_warn_chars`** tunes the threshold (`0` disables).
- `delegate` command + skill updated: use `--digest` for bulk reads; don't ingest a flagged dump.

## 2. Internal fan-out recipe + `agy-trace` (verified on agy 1.0.12, headless)

From a community pointer to upstream `antigravity-cli#105`: agy's `invoke_subagent` sandbox only allows TypeNames **`self`/`research`** — custom TypeNames are rejected with the `CORTEX_STEP_TYPE_INVOKE_SUBAGENT` error. Verified end-to-end headless:

- The **role-delegation pattern** (TypeName `"self"` + a specialist `Role`) works, including parallel spawns — documented as a new skill recipe. One delegation → agy fans out internally → coordination tokens land on the **cheap side** instead of the frontier side.
- **Spawning needs no `--yolo`** (writes inside the subagents' work still do).
- **Discovery:** each spawned subagent leaves a **readable step-by-step `transcript.jsonl`** under `~/.gemini/antigravity-cli/brain/<conversationId>/` — unlike the opaque conversation `.db` blobs. New **`agy-trace`** (script + bin shim) pretty-prints one by conversationId or path, lists recent ones (`--list`), or emits raw JSONL (`--raw`) — a real trajectory audit for subagent work. The skill's trajectory-check gate now points at it.
- Caveat documented honestly: `self`+Role is a workaround around the sandbox allowlist, not a documented contract — re-verify after agy upgrades.

## 3. Issue templates + `docs/TROUBLESHOOTING.md`

Every environment bug so far (#6, #10, #11, #15) was diagnosed from the same three facts, so ask for them up front:

- **Bug form** requires `agy-doctor` output, OS/platform, and **install method** (marketplace vs `--plugin-dir` — the #11 class). "`agy-doctor` not found" is itself flagged as diagnostic (pre-0.14.0 install).
- **`docs/TROUBLESHOOTING.md`**: symptom-first — `$CLAUDE_PLUGIN_ROOT` empty path → update; Windows headless hang incl. the *"agy works when I type it"* console explanation; WSL `/mnt` 9p slowness; silent no-write without `--yolo`; exit-code/`AGY_SIGNAL` table; tier remaps; update steps. Linked from README.

## Verification

- **105 tests pass** (+14 across both commits: digest contract/guard thresholds, trace by id/path/`--raw`/`--list`, unknown id → exit 2, bin shim forwards, exec bits)
- shellcheck clean (incl. `bin/*`) · `claude plugin validate` passes · template YAML validated
- `doctor` covers the new script/shim · version `0.16.0`, SKILL/plugin.json in sync