### PR TITLE
docs: internal fan-out recipe updated for agy 1.0.16 (0.16.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.16.1
+- **Internal fan-out recipe updated for agy 1.0.16** (re-verified per the recipe's own
+  "re-verify after upgrades" caveat — which became real within a day): **dynamic custom
+  subagents now work** — `define_subagent` a named specialist in-session, then
+  `invoke_subagent` it by TypeName (1.0.13–1.0.15 shipped this broken, upstream #521;
+  fixed in 1.0.16 via the JSON→Markdown definition change). The `self`+Role pattern
+  stays as the any-version fallback (re-verified on 1.0.16). `transcript.jsonl`
+  location is unchanged across 1.0.12→1.0.16, so `agy-trace` is unaffected. The recipe
+  now flags the whole surface as fast-moving (4 upstream releases in a week; official
+  static agent-config docs drift from behavior, upstream #527).
+
 ## 0.16.0
 - **Internal fan-out recipe + `agy-trace`** (community pointer to upstream
   antigravity-cli#105; **verified headless on agy 1.0.12**): agy's `invoke_subagent`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ you → Claude Code (conduct: design / verify / review)
 - **Adds tools Claude lacks natively** — live **Google/web search**, **Vertex AI Search** over your internal data, deep research, Cloud Logging. Claude reviews and re-checks the results.
 - **Cross-model verification** — an independent, different-model opinion on your code.
 - **Background jobs** — fire a long delegation, keep working, collect later.
-- **Internal fan-out** — one delegation, and agy spawns role-assigned subagents on the cheap side (`TypeName "self"` + Role); each leaves a **readable trajectory** you audit with `agy-trace`.
+- **Internal fan-out** — one delegation, and agy spawns its own subagents on the cheap side (dynamic `define_subagent` on agy ≥ 1.0.16; `TypeName "self"` + Role on any version); each leaves a **readable trajectory** you audit with `agy-trace`.
 - **Built-in cost discipline** — measured, not guessed (see below).
 - **Drops in with the discipline on** — a `SessionStart` hook injects the *cost-aware*
   routing policy automatically (toggle in plugin settings), and the `antigravity-delegate`

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.16.0
+version: 0.16.1
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -223,12 +223,20 @@ ROOT=agy-delegate
 
 ## Internal fan-out recipe (agy spawns its own subagents)
 
-agy has a built-in `invoke_subagent` tool, but its sandbox only allows the pre-approved
-TypeNames **`self`** and **`research`** — a custom TypeName is rejected with
-`CORTEX_STEP_TYPE_INVOKE_SUBAGENT: ... not found or not allowed to be invoked`, even if
-it appears in `/agents` (upstream issue antigravity-cli#105). The working pattern
-(**verified headless on agy 1.0.12**) is **role delegation**: invoke TypeName `self` and
-inject the specialty via `Role` + `Prompt`.
+agy has built-in `define_subagent` / `invoke_subagent` tools. Which pattern works is
+**version-dependent** — this surface is moving fast upstream (4 releases in one week
+while we tracked it), so re-verify after any agy upgrade:
+
+- **agy ≥ 1.0.16 — dynamic custom subagents (preferred):** have agy `define_subagent` a
+  named specialist in-session (name / description / system_prompt), then
+  `invoke_subagent` it by that TypeName. **Verified headless on 1.0.16**: define →
+  invoke → result round-trips cleanly, real thread spawned. (1.0.13–1.0.15 shipped this
+  broken — defined agents failed to invoke, upstream #521; fixed in 1.0.16.)
+- **Any version — role delegation (fallback):** the sandbox pre-approves TypeNames
+  **`self`** and **`research`**; an *undefined* custom TypeName is rejected with
+  `CORTEX_STEP_TYPE_INVOKE_SUBAGENT: ... not found or not allowed to be invoked`
+  (upstream #105). Invoke TypeName `self` and inject the specialty via `Role` +
+  `Prompt` — verified on 1.0.12 **and re-verified on 1.0.16**.
 
 Use it for **orchestrator-mode work pushed down a level**: instead of Claude dispatching
 N parallel `agy-job` runs (N round-trips, coordination spend on the frontier side), send
@@ -236,6 +244,8 @@ ONE delegation and let agy fan out internally — the coordination tokens land o
 cheap side, and you ingest a single digest.
 
 ```bash
+# Any version (fallback form). On agy >= 1.0.16, swap the instruction to:
+# "define_subagent a named specialist per unit, then invoke each by its TypeName".
 agy-delegate --dir . --digest --timeout 10m \
   "Decompose <task> into up to 3 units. For each unit, invoke a background subagent
    with TypeName \"self\" and a specialist Role (e.g. 'Test Writer'), each following
@@ -243,20 +253,24 @@ agy-delegate --dir . --digest --timeout 10m \
    conversationId, and end with a DIGEST line."
 ```
 
-Verified behaviors (agy 1.0.12):
+Verified behaviors (1.0.12 → 1.0.16):
 - **Spawning needs no `--yolo`** — subagent invocation isn't permission-gated; file
   writes / web tools *inside* the subagents' work still need it.
 - Each spawn's tool result includes a `logAbsoluteUri` → a **readable step-by-step
   `transcript.jsonl`** under `~/.gemini/antigravity-cli/brain/<conversationId>/` —
-  *better* trajectory visibility than a plain delegation. Have the parent report each
-  `conversationId`, then audit with `agy-trace <id>` (`agy-trace --list` finds recent ones).
+  *better* trajectory visibility than a plain delegation. Location unchanged across
+  1.0.12→1.0.16, for both `define_subagent` and `self` spawns. Have the parent report
+  each `conversationId`, then audit with `agy-trace <id>` (`agy-trace --list` finds
+  recent ones).
 - Spawns are real and observable (new conversation threads appear) — but still run the
   verification gates on the merged result; more autonomy = more surface for error.
 
-Caveats: `self`+Role is a **workaround around the sandbox allowlist**, not a documented
-contract — re-verify after agy upgrades. Bound the fan-out width in the prompt (agy
-chooses parallelism otherwise). A wide fan-out takes longer wall-clock — raise
-`--timeout`, and in an interactive session prefer a background job (`agy-job`).
+Caveats: neither pattern is a documented contract yet — `self`+Role works around the
+sandbox allowlist, and even the official docs' static agent-config paths don't match
+observed behavior (upstream #527) — so **re-verify after agy upgrades** (1.0.16 changed
+this area within a day of our first verification). Bound the fan-out width in the
+prompt (agy chooses parallelism otherwise). A wide fan-out takes longer wall-clock —
+raise `--timeout`, and in an interactive session prefer a background job (`agy-job`).
 
 ## Deep-research recipe (multi-source)
 


### PR DESCRIPTION
The recipe's own "re-verify after agy upgrades" caveat became real within a day — 4 upstream releases in the week since v0.16.0 shipped. Re-verified everything on **agy 1.0.16**:

- **`define_subagent` → `invoke_subagent` with a custom TypeName now works headless** (verified: define → invoke → result round-trips, real thread spawned). 1.0.13–1.0.15 shipped this broken (upstream #521); fixed in 1.0.16. The recipe now presents it as the **preferred pattern on ≥ 1.0.16**.
- **`self`+Role stays as the any-version fallback** (re-verified on 1.0.16; undefined custom TypeNames still rejected with the CORTEX allowlist error).
- **`transcript.jsonl` location unchanged** across 1.0.12→1.0.16 for both spawn kinds → `agy-trace` unaffected.
- Caveats widened: official static agent-config docs drift from behavior (upstream #527); the whole surface is fast-moving.

README fan-out bullet generalized. Version **0.16.1** so marketplace installs pick up the corrected guidance.

105 tests pass · shellcheck clean · `claude plugin validate` passes.