### PR TITLE
feat: frictionless delegation — proactive subagent + prompt-level nudge (0.17.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"
@@ -66,6 +66,12 @@
       "title": "Digest-size warning threshold (chars)",
       "description": "agy-delegate warns on stderr when a reply exceeds this many characters — a raw dump instead of the digest the cost discipline calls for. Empty = 8000. Set 0 to disable.",
       "default": ""
+    },
+    "delegation_nudge": {
+      "type": "string",
+      "title": "Nudge delegation on bulk-looking prompts",
+      "description": "When on, a UserPromptSubmit hook adds a short advisory note to Claude's context when a prompt looks like bulk work above the delegation break-even (mass edits, migrations, exhaustive tests, fan-out search). Advisory only — Claude still makes the break-even judgment per task. Set to off/false/0/no to suppress.",
+      "default": "on"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.17.0
+- **Frictionless delegation — no slash command required, judgment stays with Claude.**
+  Two additions reduce the "you must type `/antigravity:delegate` every time" friction,
+  while deliberately NOT auto-routing (full automation below the break-even is a
+  measured net loss):
+  - **Proactive subagent selection**: the `antigravity-delegate` description now tells
+    Claude to use it *proactively* for bulk work (scaffolding / exhaustive tests /
+    migrations / fan-out search) — with the explicit counterweight that the break-even
+    judgment is Claude's, every time.
+  - **Prompt-level nudge** (`hooks/nudge-delegation.sh`, UserPromptSubmit): a cheap,
+    deterministic heuristic (volume/fan-out phrases, EN + JA) adds a short advisory note
+    when a prompt looks above the break-even. Advisory material only — the note itself
+    says "THE JUDGMENT IS YOURS". Only the `prompt` field is scanned (no cwd/path false
+    positives), the user's prompt is never echoed back (no injection surface), and it
+    stays silent when the user is already delegating. Toggle via the new
+    `delegation_nudge` plugin option.
+
 ## 0.16.1
 - **Internal fan-out recipe updated for agy 1.0.16** (re-verified per the recipe's own
   "re-verify after upgrades" caveat — which became real within a day): **dynamic custom

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ you → Claude Code (conduct: design / verify / review)
 - **Drops in with the discipline on** — a `SessionStart` hook injects the *cost-aware*
   routing policy automatically (toggle in plugin settings), and the `antigravity-delegate`
   subagent does file **writing** on Gemini, so Claude spends **no tokens generating file contents**.
+- **No slash command required** — the delegate subagent is picked up **proactively** for bulk
+  work, and a prompt-level nudge flags bulk-looking requests as delegation candidates.
+  Both are advisory: **the break-even judgment stays with Claude** (full auto-routing is a
+  measured net loss below the break-even), and the nudge is toggleable (`delegation_nudge`).
 
 ## 📊 Measured results
 

--- a/agents/antigravity-delegate.md
+++ b/agents/antigravity-delegate.md
@@ -1,13 +1,15 @@
 ---
 name: antigravity-delegate
 description: |
-  Use this subagent to hand a well-scoped, ABOVE-break-even unit of work to the
-  Antigravity CLI (agy / Gemini) through the plugin wrapper — bulk scaffolding,
-  exhaustive test generation, migrations, long-context reads that distill to a
-  digest, or fan-out web / Vertex AI Search. Its only file-acting tool is the
-  delegation wrapper, so the file generation and bulky reading happen on Gemini
-  and do NOT spend Claude tokens. It returns agy's DIGEST for the caller to verify
-  — it does not itself ship or claim success.
+  Use this subagent PROACTIVELY — don't wait for the user to ask for delegation —
+  whenever a task contains a well-scoped, ABOVE-break-even unit of work for the
+  Antigravity CLI (agy / Gemini): bulk scaffolding, exhaustive test generation,
+  migrations, long-context reads that distill to a digest, or fan-out web /
+  Vertex AI Search. Proactive means YOU decide without being prompted — not that
+  you delegate everything: the break-even judgment is yours, every time. Its only
+  file-acting tool is the delegation wrapper, so the file generation and bulky
+  reading happen on Gemini and do NOT spend Claude tokens. It returns agy's
+  DIGEST for the caller to verify — it does not itself ship or claim success.
 
   Do NOT use it for small, self-contained, or judgement-heavy tasks: delegating a
   tiny task is a measured net loss (round-trip cost exceeds the savings) — the

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -19,6 +19,13 @@
           { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/inject-policy.sh\"" }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/nudge-delegation.sh\"" }
+        ]
+      }
     ]
   }
 }

--- a/hooks/nudge-delegation.sh
+++ b/hooks/nudge-delegation.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# UserPromptSubmit hook: a cheap, deterministic nudge toward delegation when the
+# user's prompt LOOKS like bulk work above the delegation break-even.
+#
+# Design principle: this supplies judgment MATERIAL — the DECISION stays with
+# Claude (per the skill's cost discipline). It never forces a delegation and it
+# never fires the wrapper itself: full automation is a measured net loss below
+# the break-even, so the break-even call must remain a per-task judgment.
+#
+# Heuristic is deliberately conservative (volume/fan-out phrases, EN + JA), and
+# the nudge text is a FIXED string — the user's prompt is never echoed back into
+# the context (no escaping/injection surface).
+#
+# Toggle via plugin userConfig `delegation_nudge`
+# (env CLAUDE_PLUGIN_OPTION_DELEGATION_NUDGE: off/false/0/no/disabled). Default: on.
+#
+set -uo pipefail
+
+raw="$(printf '%s' "${CLAUDE_PLUGIN_OPTION_DELEGATION_NUDGE:-on}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+case "$raw" in off|false|0|no|disabled) exit 0 ;; esac
+
+IN="$(cat 2>/dev/null || true)"
+[ -n "$IN" ] || exit 0
+
+# Extract ONLY the prompt field (matching on the whole payload would false-positive
+# on cwd/paths). python3 is already a plugin dependency (measure-session, agy-trace).
+PROMPT="$(printf '%s' "$IN" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("prompt",""))
+except Exception: pass' 2>/dev/null || true)"
+[ -n "$PROMPT" ] || exit 0
+
+# Already delegating explicitly? Stay quiet.
+case "$PROMPT" in *antigravity*|*agy-delegate*|*agy-job*) exit 0 ;; esac
+
+shopt -s nocasematch
+HIT=0
+case "$PROMPT" in
+  *"all files"*|*"every file"*|*"across the codebase"*|*"entire codebase"*|*"whole repo"*| \
+  *migrate*|*migration*|*"generate tests"*|*"test coverage"*|*"exhaustive test"*| \
+  *scaffold*|*boilerplate*|*"deep research"*|*"web search"*| \
+  *一括*|*全ファイル*|*すべてのファイル*|*網羅*|*移行*|*大量*|*横断*|*リポジトリ全体*)
+    HIT=1 ;;
+esac
+shopt -u nocasematch
+[ "$HIT" -eq 1 ] || exit 0
+
+# Fixed nudge. Note the explicit "the judgment is yours" — this is material, not a mandate.
+cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"[antigravity plugin] This prompt looks like BULK work (mass edits / migration / exhaustive tests / fan-out search) — possibly above the delegation break-even. CONSIDER routing the bulk part to the antigravity-delegate subagent (or agy-delegate --digest) so it runs on the cheap executor, then verify its digest. THE JUDGMENT IS YOURS: if the task is actually small, self-contained, or judgement-heavy, do it yourself — delegating below the break-even is a measured net loss. Decide silently; don't mention this notice."}}
+JSON
+exit 0

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -114,7 +114,7 @@ for s in agy-delegate.sh agy-cost-compare.sh cloud-debug.sh agy-trace.sh; do
 done
 
 # 4b. SessionStart hooks executable
-for h in check-agy.sh inject-policy.sh validate-delegate-bash.sh; do
+for h in check-agy.sh inject-policy.sh validate-delegate-bash.sh nudge-delegation.sh; do
   if [ -x "$ROOT/hooks/$h" ]; then ok "hooks/$h executable"; else
     bad "hooks/$h not executable"; info "fix: chmod +x \"$ROOT/hooks/$h\""
   fi

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.16.1
+version: 0.17.0
 ---
 
 # Antigravity for Claude Code — hybrid SDLC

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -293,16 +293,40 @@ check "check-agy (agy present) -> exit 0" 0 "$rc"
 err=$( { PATH="/usr/bin:/bin" "$HOOKS/check-agy.sh" >/dev/null; } 2>&1 ); rc=$?
 check "check-agy (agy absent) -> exit 0 + warns" 0 "$rc" "not on PATH" "$err"
 
-# hooks.json structural shape (SessionStart command hooks referencing the plugin root)
+# hooks.json structural shape (all events: command hooks referencing the plugin root)
 python3 - "$HOOKS/hooks.json" <<'PY' 2>/dev/null; rc=$?
 import json,sys
-ss=json.load(open(sys.argv[1]))["hooks"]["SessionStart"]
-assert isinstance(ss,list) and ss
-for g in ss:
-    for h in g["hooks"]:
-        assert h["type"]=="command" and "CLAUDE_PLUGIN_ROOT" in h["command"]
+hooks=json.load(open(sys.argv[1]))["hooks"]
+assert hooks.get("SessionStart") and hooks.get("UserPromptSubmit")
+for groups in hooks.values():
+    assert isinstance(groups,list) and groups
+    for g in groups:
+        for h in g["hooks"]:
+            assert h["type"]=="command" and "CLAUDE_PLUGIN_ROOT" in h["command"]
 PY
-check "hooks.json SessionStart shape valid" 0 "$rc"
+check "hooks.json shape valid (SessionStart + UserPromptSubmit)" 0 "$rc"
+
+# nudge-delegation (UserPromptSubmit): advisory material only — never a mandate
+NUDGE="$HOOKS/nudge-delegation.sh"
+out=$(printf '%s' '{"prompt":"migrate every caller from APIv1 to APIv2 across the codebase"}' | "$NUDGE" 2>/dev/null); rc=$?
+check "nudge fires on bulk EN prompt" 0 "$rc" "additionalContext" "$out"
+check "nudge preserves Claude's judgment (not a mandate)" 0 "$rc" "THE JUDGMENT IS YOURS" "$out"
+printf '%s' "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['hookSpecificOutput']['hookEventName']=='UserPromptSubmit'" 2>/dev/null; rc=$?
+check "nudge emits valid UserPromptSubmit JSON" 0 "$rc"
+out=$(printf '%s' '{"prompt":"リポジトリ全体のテストを網羅的に生成して"}' | "$NUDGE" 2>/dev/null); rc=$?
+check "nudge fires on bulk JA prompt" 0 "$rc" "additionalContext" "$out"
+out=$(printf '%s' '{"prompt":"fix the typo in README"}' | "$NUDGE" 2>/dev/null); rc=$?
+if [ "$rc" = 0 ] && [ -z "$out" ]; then echo "ok: nudge silent on a small prompt"; PASS=$((PASS+1));
+else echo "FAIL: nudge fired on a small prompt (rc=$rc)"; FAIL=$((FAIL+1)); fi
+out=$(printf '%s' '{"prompt":"/antigravity:delegate migrate everything"}' | "$NUDGE" 2>/dev/null)
+if [ -z "$out" ]; then echo "ok: nudge silent when already delegating"; PASS=$((PASS+1));
+else echo "FAIL: nudge fired on an antigravity command"; FAIL=$((FAIL+1)); fi
+out=$(printf '%s' '{"prompt":"migrate all files"}' | CLAUDE_PLUGIN_OPTION_DELEGATION_NUDGE=off "$NUDGE" 2>/dev/null)
+if [ -z "$out" ]; then echo "ok: delegation_nudge=off suppresses the nudge"; PASS=$((PASS+1));
+else echo "FAIL: nudge fired while disabled"; FAIL=$((FAIL+1)); fi
+out=$(printf '%s' '{"prompt":"hello","cwd":"/home/u/migration-tool"}' | "$NUDGE" 2>/dev/null)
+if [ -z "$out" ]; then echo "ok: nudge scans only the prompt field (cwd noise ignored)"; PASS=$((PASS+1));
+else echo "FAIL: nudge matched a non-prompt field"; FAIL=$((FAIL+1)); fi
 
 echo "== delegate subagent guardrail =="
 GATE="$HOOKS/validate-delegate-bash.sh"
@@ -325,6 +349,10 @@ else echo "FAIL: delegate agent tools line unexpected: '$tl'"; FAIL=$((FAIL+1));
 if grep -q "PreToolUse" "$AGENT" && grep -q "validate-delegate-bash.sh" "$AGENT"; then
   echo "ok: delegate agent wires the PreToolUse Bash gate"; PASS=$((PASS+1));
 else echo "FAIL: delegate agent missing PreToolUse gate"; FAIL=$((FAIL+1)); fi
+# proactive auto-selection, WITH the judgment kept on Claude (not "delegate everything")
+if grep -q "PROACTIVELY" "$AGENT" && grep -q "break-even judgment is yours" "$AGENT"; then
+  echo "ok: delegate agent is proactive AND keeps the break-even judgment"; PASS=$((PASS+1));
+else echo "FAIL: delegate agent missing proactive-with-judgment description"; FAIL=$((FAIL+1)); fi
 
 echo "== bin/ entrypoints (issue #11: \$CLAUDE_PLUGIN_ROOT not on model-run Bash) =="
 BIN="$ROOT/bin"
@@ -445,10 +473,10 @@ plugins = mp.get("plugins", [])
 need(bool(plugins) and plugins[0].get("source") == "./", "marketplace plugins[0].source != ./")
 need(bool(plugins) and plugins[0].get("name") == pj.get("name"), "marketplace plugin name != plugin.json name")
 
-# every SessionStart hook command resolves to a real file
+# every hook command (all events) resolves to a real file
 hj = json.load(open(p("hooks", "hooks.json")))
-cmds = [h["command"] for grp in hj["hooks"].get("SessionStart", []) for h in grp["hooks"]]
-need(bool(cmds), "no SessionStart hook commands")
+cmds = [h["command"] for groups in hj["hooks"].values() for grp in groups for h in grp["hooks"]]
+need(bool(cmds), "no hook commands")
 for c in cmds:
     m = re.search(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\"']+)", c)
     need(bool(m), "hook command missing CLAUDE_PLUGIN_ROOT path: " + c)
@@ -467,7 +495,7 @@ m = re.search(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\"']+\.sh)", agent)
 need(bool(m), "agent PreToolUse gate path not found")
 if m: need(os.path.isfile(p(m.group(1))), "agent gate references missing file: " + m.group(1))
 
-for s in ("hooks/check-agy.sh", "hooks/inject-policy.sh", "hooks/validate-delegate-bash.sh"):
+for s in ("hooks/check-agy.sh", "hooks/inject-policy.sh", "hooks/validate-delegate-bash.sh", "hooks/nudge-delegation.sh"):
     need(os.access(p(s), os.X_OK), "not executable: " + s)
 
 # bin/ entrypoints exist + executable (issue #11: $CLAUDE_PLUGIN_ROOT isn't exported


### PR DESCRIPTION
Reduces the "you must type `/antigravity:delegate` every time" friction — **without auto-routing**. Full automation below the break-even is a measured net loss, so both mechanisms supply judgment *material* and leave the *decision* with Claude.

## 1. Proactive subagent selection

`antigravity-delegate`'s description now instructs **PROACTIVE** use for bulk work (scaffolding / exhaustive tests / migrations / fan-out search) — Claude Code auto-selects subagents by description, so bulk tasks route to the cheap executor without the user typing anything. The same description carries the explicit counterweight: *"the break-even judgment is yours, every time — proactive means you decide without being prompted, not that you delegate everything."*

## 2. Prompt-level nudge (`hooks/nudge-delegation.sh`, UserPromptSubmit)

A cheap, deterministic heuristic (volume/fan-out phrases, EN + JA) adds a short advisory note when a prompt looks above the delegation break-even.

Safety properties:
- Scans **only the `prompt` field** — no cwd/path false positives
- **Never echoes the user's prompt back** into context — no escaping/injection surface
- Silent when the user is already delegating (`/antigravity:*`, `agy-delegate`, `agy-job`)
- The note itself says **"THE JUDGMENT IS YOURS"** — material, not a mandate
- Toggle via new `delegation_nudge` plugin option (default on)

## Plumbing
- `hooks.json`: `UserPromptSubmit` wired; contract test now validates **all** hook events (was SessionStart-only)
- `doctor` covers the new hook; README documents the no-slash-command behavior
- Version `0.17.0`

## Verification
- **114 tests pass** (+9: EN/JA fire, small-prompt silent, already-delegating silent, off-toggle, prompt-field-only scan, valid UserPromptSubmit JSON, judgment-preserving text, proactive-with-judgment agent description)
- shellcheck clean · `claude plugin validate` passes