### PR TITLE
feat: agy 1.1.0 support — --mode accept-edits|plan passthrough (0.18.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.18.0
+- **agy 1.1.0 support — `--mode accept-edits|plan` passthrough** (all behaviors below
+  verified live on 1.1.0):
+  - 1.1.0 makes **review-first** the default execution mode. Headless consequence
+    (measured): a write task **without** write permission no longer just "describes" —
+    agy writes the files to its **own scratch dir** (`~/.gemini/antigravity-cli/scratch`)
+    and reports success, while your workspace stays untouched (the evolved #10 failure
+    mode).
+  - New wrapper flag **`--mode accept-edits`**: auto-applies FILE EDITS to the real
+    workspace *without* granting terminal/tool permissions — a **narrower grant than
+    `--yolo`**, now the recommended way to run pure write delegations. `--yolo` remains
+    for tasks that also need tools (web / Vertex AI Search / terminal); verified
+    backward-compatible on 1.1.0. `--mode plan` passes through for strategize-only runs.
+  - The write-task warning now fires only when *neither* `--mode accept-edits` nor
+    `--yolo` is set, and explains the scratch-divert behavior.
+  - Subagents re-verified on 1.1.0 (`define_subagent` → `invoke_subagent`, transcript
+    path unchanged); they are **officially documented** as of 1.1.0, with static config
+    at `<workspace>/.agents/agents/*.md` and global `~/.gemini/config/agents/` — the
+    skill's fan-out recipe now points at the official docs.
+  - `delegate` command, skill safety section, and README write guidance updated to the
+    "prefer `--mode accept-edits`, escalate to `--yolo` only for tools" split.
+
 ## 0.17.0
 - **Frictionless delegation — no slash command required, judgment stays with Claude.**
   Two additions reduce the "you must type `/antigravity:delegate` every time" friction,

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ scripts/agy-delegate.sh --tier pro --dir ./src "List every TODO with file:line"
 # bulk read -> digest-only reply (the biggest cost lever; wrapper warns on dump-sized replies)
 scripts/agy-delegate.sh --digest --dir . "Map the auth flow end to end"
 
+# write task: auto-apply FILE edits without granting terminal/tools (agy >= 1.1.0)
+scripts/agy-delegate.sh --mode accept-edits --dir ./app "Implement X per SPEC.md"
+
 # live web / Google search (tools need --yolo in headless mode)
 scripts/agy-delegate.sh --tier pro --yolo "Web-search <X>. Give URLs + dates."
 
@@ -164,7 +167,7 @@ Delegation doesn't save money by itself — these do (also in the skill):
 **Known limits (agy v1.0.x)**
 - `-p`/`--print` **takes the prompt as its value** and must come last — the wrapper handles this.
 - No `--output-format json` (plain text); `--print` drops stdout on a non-TTY unless stdin is detached (handled via `< /dev/null`).
-- **Writes need `--yolo`:** without it, headless agy only *describes* edits and returns a confident success **without writing any files** ([issue #10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)). Pass `--yolo` for write tasks (on a branch); Claude Code may prompt for / block `--dangerously-skip-permissions` — approve it or pre-allow it. Long write tasks can exceed the ~2-min sync Bash limit → use a background job.
+- **Writes need write permission:** without it, headless agy describes the edits or (agy ≥ 1.1.0, review-first default) writes them to its **own scratch dir** — your workspace stays untouched while agy reports success ([issue #10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)). Prefer **`--mode accept-edits`** (agy ≥ 1.1.0; file edits only, no terminal/tool grant); use `--yolo` when the task also needs tools (web / Vertex AI Search). Run write tasks on a branch and verify files actually changed. Long write tasks can exceed the ~2-min sync Bash limit → use a background job.
 - **Native Windows (no ConPTY):** headless `agy -p` / `agy models` can hard-hang with a 0-byte log when stdio is redirected ([issue #6](https://github.com/yuting0624/antigravity-for-claude-code/issues/6)). The wrapper wraps agy in a wall-clock `timeout`/`gtimeout` guard so it returns a structured TIMEOUT (exit 12) instead of hanging; `doctor` reports the likely hang instead of a misleading "not authenticated". Without `timeout` on PATH there's no safety net — use **WSL/macOS/Linux** for headless delegation.
 - **WSL:** running agy with `--add-dir` on a Windows mount (`/mnt/c/...`) is very slow — agy reads the workspace over a 9p bridge, so even trivial calls can take 20s+. Keep the repo on the WSL Linux filesystem (`~`). The wrapper and `doctor` warn about this.
 

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -11,14 +11,19 @@ Task: $ARGUMENTS
 Do this:
 1. Pick a tier (`flash` default; `pro` for hard reasoning). If the task needs the repo,
    add `--dir <repo-root>` so agy reads the real files (don't paste them into context).
-   **If the task WRITES files or uses tools** (implement / scaffold / test-gen / migrate /
-   fix, or web / Vertex AI Search) **add `--yolo`** — without it, agy only *describes* the
-   edits and returns a confident "done" **while writing nothing** (issue #10). Run write
-   tasks on a dedicated branch (+ `--sandbox`). Note: Claude Code may prompt for or block
-   `--yolo` (`--dangerously-skip-permissions`) — approve it when asked, or pre-allow it in
-   settings; non-interactive (`claude -p`) without that permission can't write via agy.
+   **If the task WRITES files**, grant write permission — without it, headless agy
+   describes the edits or writes them to its **own scratch dir**, NOT your workspace,
+   while still reporting success (issue #10):
+   - Pure file writes (implement / scaffold / test-gen / migrate / fix): **`--mode
+     accept-edits`** (agy ≥ 1.1.0) — auto-applies edits *without* granting terminal/tool
+     permissions. Prefer this.
+   - Task also needs tools (web / Vertex AI Search / terminal): **`--yolo`**. Claude Code
+     may prompt for or block `--dangerously-skip-permissions` — approve it when asked, or
+     pre-allow it; non-interactive (`claude -p`) without that permission can't use tools via agy.
+   - Either way: run write tasks on a dedicated branch (+ `--sandbox`), and **verify files
+     actually changed in the workspace** (`git status`).
 2. Run **synchronously** (you may be headless — do not background-and-wait):
-   `agy-delegate --tier <tier> [--dir .] [--yolo] [--digest] "<task>"`
+   `agy-delegate --tier <tier> [--dir .] [--mode accept-edits | --yolo] [--digest] "<task>"`
    For read/analysis tasks, add `--digest` — it appends a digest-only output contract so
    agy returns compact bullets instead of raw content.
 3. Ingest only the **result/digest** — do NOT re-read the files agy already handled

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -27,6 +27,10 @@
 #       --sandbox                    Run agent with terminal sandbox restrictions
 #       --digest                     Append a digest-only output contract to the prompt
 #                                    (ingest digests, not raw dumps — the biggest cost lever)
+#       --mode <accept-edits|plan>   agy execution mode (agy >= 1.1.0). accept-edits: auto-apply
+#                                    FILE EDITS to the workspace without granting terminal/tool
+#                                    permissions (the safer choice for pure write tasks — narrower
+#                                    than --yolo). plan: strategize only, touch nothing.
 #   -c, --continue                   Resume the most recent agy conversation (stateful)
 #       --conversation <id>          Resume a specific agy conversation by ID (stateful)
 #   -m, --model <exact name>         Use an exact agy model (any from `agy models`: Gemini/Claude/GPT…)
@@ -53,6 +57,7 @@ MODEL=""
 YOLO=0
 SANDBOX=0
 DIGEST=0
+MODE=""
 ADD_DIRS=()
 PROMPT=""
 CONTINUE=0
@@ -142,6 +147,10 @@ while [ $# -gt 0 ]; do
     --yolo)         YOLO=1; shift ;;
     --sandbox)      SANDBOX=1; shift ;;
     --digest)       DIGEST=1; shift ;;               # ask agy for a digest-only reply
+    --mode)         need "$#" "$1"; MODE="$2"; shift 2
+                    case "$MODE" in accept-edits|plan) ;;
+                      *) die "invalid --mode '$MODE' (use accept-edits | plan; agy >= 1.1.0)" ;;
+                    esac ;;
     -c|--continue)  CONTINUE=1; shift ;;            # resume most recent agy conversation
     --conversation) need "$#" "$1"; CONV_ID="$2"; shift 2 ;; # resume a specific conversation by ID
     -m|--model)     need "$#" "$1"; MODEL="$2"; shift 2 ;;
@@ -192,14 +201,16 @@ if on_wsl; then
   done
 fi
 
-# Heads-up: a likely write task without --yolo. Without --yolo, headless agy only
-# DESCRIBES edits and returns success without writing any files (issue #10). Best-effort
-# heuristic; warn only. --print-command (dry run) is exempt.
-if [ "$YOLO" -eq 0 ] && [ "$PRINT_CMD" -ne 1 ]; then
+# Heads-up: a likely write task without write permission. Headless agy without
+# --mode accept-edits / --yolo either only DESCRIBES edits (pre-1.1.0) or writes them
+# to its OWN scratch dir (~/.gemini/antigravity-cli/scratch, 1.1.0 review-first default)
+# — either way YOUR WORKSPACE IS UNTOUCHED while agy reports success (issue #10).
+# Best-effort heuristic; warn only. --print-command (dry run) is exempt.
+if [ "$YOLO" -eq 0 ] && [ "$MODE" != "accept-edits" ] && [ "$PRINT_CMD" -ne 1 ]; then
   shopt -s nocasematch
   case "$PROMPT" in
     *implement*|*scaffold*|*migrate*|*refactor*|*"write the file"*|*"create the file"*|*"edit the file"*)
-      echo "agy-delegate: note: this looks like a write task but --yolo is not set — without it agy only DESCRIBES edits and writes nothing (still returns success). Add --yolo (and run on a branch) to actually write files." >&2 ;;
+      echo "agy-delegate: note: this looks like a write task but neither --mode accept-edits nor --yolo is set — headless agy will describe the edits or write them to its own scratch dir, NOT your workspace, while still reporting success (issue #10). Use --mode accept-edits for pure file writes (agy >= 1.1.0), or --yolo when the task also needs tools (web/terminal); run write tasks on a branch." >&2 ;;
   esac
   shopt -u nocasematch
 fi
@@ -220,6 +231,7 @@ fi
 ARGS=(--model "$MODEL" --print-timeout "$TIMEOUT")
 for d in "${ADD_DIRS[@]:-}"; do [ -n "$d" ] && ARGS+=(--add-dir "$d"); done
 [ "$YOLO" -eq 1 ]      && ARGS+=(--dangerously-skip-permissions)
+[ -n "$MODE" ]         && ARGS+=(--mode "$MODE")     # agy >= 1.1.0
 [ "$SANDBOX" -eq 1 ]   && ARGS+=(--sandbox)
 [ "$CONTINUE" -eq 1 ]  && ARGS+=(--continue)        # keep working context on the cheap (Gemini) side
 [ -n "$CONV_ID" ]      && ARGS+=(--conversation "$CONV_ID")

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.17.0
+version: 0.18.0
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -61,8 +61,11 @@ the cross-model verification value (Claude executing Claude loses both).
 agy-delegate [options] "the task prompt"
 ```
 Options: `--tier flash|flash-lo|pro` · `--dir <path>` (workspace, repeatable) ·
-`--timeout 10m` · `--yolo` (auto-approve tools — needed for any tool use in headless
-mode) · `--sandbox` · `--digest` (append a digest-only output contract — use it for any
+`--timeout 10m` · `--mode accept-edits|plan` (agy ≥ 1.1.0 — `accept-edits` auto-applies
+FILE EDITS to the workspace *without* granting terminal/tools: the safer choice for pure
+write tasks; `plan` touches nothing) · `--yolo` (auto-approve ALL tools — needed for
+web/terminal use in headless mode; broader than `--mode accept-edits`) · `--sandbox` ·
+`--digest` (append a digest-only output contract — use it for any
 bulk read/analysis; the wrapper also warns on stderr when a reply comes back dump-sized,
 because ingesting digests instead of dumps is the single biggest cost lever) ·
 `--print-command` (dry run: show the resolved `agy` call, don't run it) · pipe a long
@@ -134,10 +137,15 @@ If wrong: retry on `--tier pro`, sharpen the spec, or do that piece yourself.
 
 Read-only work (search, review, analysis) is low-risk. **When agy writes files or runs
 commands** (`--yolo` grants write + terminal):
-- **Write tasks MUST pass `--yolo`.** Without it, agy only *describes* the edits and returns a
-  confident "done" **without writing anything** (issue #10). Claude Code may also prompt for or
-  block `--dangerously-skip-permissions` — approve it or pre-allow `Bash(agy-delegate*)`. Always
-  verify the files actually changed (the gate catches the silent no-write).
+- **Write tasks MUST grant write permission.** Without it, headless agy describes the
+  edits (pre-1.1.0) or writes them to its **own scratch dir** (`~/.gemini/antigravity-cli/scratch`,
+  1.1.0 review-first default) — your workspace stays untouched while agy reports success
+  (issue #10). Prefer **`--mode accept-edits`** (agy ≥ 1.1.0, file edits only — no
+  terminal/tool grant); use **`--yolo`** only when the task also needs tools (web /
+  Vertex AI Search / terminal). Claude Code may prompt for or block
+  `--dangerously-skip-permissions` — approve it or pre-allow `Bash(agy-delegate*)`.
+  Always verify files actually changed **in the workspace** (the gate catches the
+  silent no-write / scratch divert).
 - Run it on a **dedicated git branch or worktree** so changes are isolated.
 - Add `--sandbox` for execution containment.
 - **Claude reviews the diff before merging** — never auto-merge agy's writes.
@@ -229,9 +237,12 @@ while we tracked it), so re-verify after any agy upgrade:
 
 - **agy ≥ 1.0.16 — dynamic custom subagents (preferred):** have agy `define_subagent` a
   named specialist in-session (name / description / system_prompt), then
-  `invoke_subagent` it by that TypeName. **Verified headless on 1.0.16**: define →
-  invoke → result round-trips cleanly, real thread spawned. (1.0.13–1.0.15 shipped this
-  broken — defined agents failed to invoke, upstream #521; fixed in 1.0.16.)
+  `invoke_subagent` it by that TypeName. **Verified headless on 1.0.16 and re-verified
+  on 1.1.0**: define → invoke → result round-trips cleanly, real thread spawned.
+  (1.0.13–1.0.15 shipped this broken — defined agents failed to invoke, upstream #521;
+  fixed in 1.0.16. Subagents are officially documented as of 1.1.0 —
+  antigravity.google/docs/cli/subagents — with static config at
+  `<workspace>/.agents/agents/*.md` and global `~/.gemini/config/agents/`.)
 - **Any version — role delegation (fallback):** the sandbox pre-approves TypeNames
   **`self`** and **`research`**; an *undefined* custom TypeName is rejected with
   `CORTEX_STEP_TYPE_INVOKE_SUBAGENT: ... not found or not allowed to be invoked`

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -161,15 +161,28 @@ check "--print-command shows the tier model" 0 "$rc" "Pro" "$out"
 out=$(PATH="/usr/bin:/bin" "$DELEGATE" --print-command "hi" 2>/dev/null); rc=$?
 check "--print-command works without agy on PATH" 0 "$rc" "--print-timeout" "$out"
 
-# write-task without --yolo -> warn (agy would only describe, not write) (issue #10)
+# write-task without write permission -> warn (describe-only pre-1.1.0, scratch-divert on 1.1.0) (issue #10)
 out=$(STUB_MODE=args "$DELEGATE" "implement the parser module" 2>&1); rc=$?
-check "write prompt w/o --yolo -> warns" 0 "$rc" "DESCRIBES" "$out"
+check "write prompt w/o write permission -> warns" 0 "$rc" "scratch dir" "$out"
 out=$(STUB_MODE=args "$DELEGATE" --yolo "implement the parser module" 2>&1); rc=$?
-if printf '%s' "$out" | grep -q "DESCRIBES"; then echo "FAIL: warned even with --yolo"; FAIL=$((FAIL+1));
+if printf '%s' "$out" | grep -q "scratch dir"; then echo "FAIL: warned even with --yolo"; FAIL=$((FAIL+1));
 else echo "ok: no write-warning when --yolo is set"; PASS=$((PASS+1)); fi
+out=$(STUB_MODE=args "$DELEGATE" --mode accept-edits "implement the parser module" 2>&1); rc=$?
+if printf '%s' "$out" | grep -q "scratch dir"; then echo "FAIL: warned even with --mode accept-edits"; FAIL=$((FAIL+1));
+else echo "ok: no write-warning with --mode accept-edits"; PASS=$((PASS+1)); fi
 out=$(STUB_MODE=args "$DELEGATE" "summarize the changelog in 3 bullets" 2>&1); rc=$?
-if printf '%s' "$out" | grep -q "DESCRIBES"; then echo "FAIL: warned for a non-write prompt"; FAIL=$((FAIL+1));
+if printf '%s' "$out" | grep -q "scratch dir"; then echo "FAIL: warned for a non-write prompt"; FAIL=$((FAIL+1));
 else echo "ok: no write-warning for a read/summary prompt"; PASS=$((PASS+1)); fi
+
+# --mode passthrough (agy >= 1.1.0): accept-edits reaches agy; invalid mode errors early
+out=$(STUB_MODE=args "$DELEGATE" --mode accept-edits "hi" 2>/dev/null); rc=$?
+check "--mode accept-edits passed through to agy" 0 "$rc" "--mode accept-edits" "$out"
+out=$(STUB_MODE=args "$DELEGATE" --mode plan "hi" 2>/dev/null); rc=$?
+check "--mode plan passed through to agy" 0 "$rc" "--mode plan" "$out"
+out=$("$DELEGATE" --mode bogus "hi" 2>&1); rc=$?
+check "--mode bogus -> exit 1 (friendly)" 1 "$rc" "invalid --mode" "$out"
+out=$("$DELEGATE" --mode accept-edits --print-command "hi" 2>/dev/null); rc=$?
+check "--print-command shows --mode" 0 "$rc" "--mode accept-edits" "$out"
 
 # --digest appends the digest-only output contract to the prompt (issue #5)
 out=$(STUB_MODE=args "$DELEGATE" --digest "hi" 2>/dev/null); rc=$?


### PR DESCRIPTION
agy 1.1.0 makes **review-first** the default execution mode. All behaviors below verified live on 1.1.0.

## The measured headless consequence (evolved #10)

A write task **without** write permission no longer just "describes" — agy writes the files to its **own scratch dir** (`~/.gemini/antigravity-cli/scratch`) and reports success, while your workspace stays untouched. Verified: file claimed as written landed in scratch, workspace empty.

## Changes

- **`--mode <accept-edits|plan>` passthrough** in `agy-delegate` (validated; `--print-command` shows it). `accept-edits` auto-applies FILE EDITS to the real workspace *without* granting terminal/tools — a **narrower grant than `--yolo`**, now the recommended path for pure write delegations (verified live through the wrapper). `--yolo` verified backward-compatible; still required for web/Vertex/terminal tool use.
- Write-task warning fires only when *neither* `--mode accept-edits` nor `--yolo` is set, and explains the scratch-divert.
- `delegate` command / skill safety / README: "prefer `--mode accept-edits`, escalate to `--yolo` only for tools" split.
- Fan-out recipe: subagents re-verified on 1.1.0 (`define_subagent` → `invoke_subagent`, transcript path unchanged); recipe now points at the official subagent docs + fixed static config paths.

## Verification
- **119 tests pass** (+6: `--mode` passthrough ×2, bogus mode → exit 1, dry-run shows mode, no-warning with accept-edits, updated warning text)
- shellcheck clean · `claude plugin validate` passes
- **Live smoke on agy 1.1.0**: wrapper + `--mode accept-edits` writes to the real workspace ✓