### PR TITLE
feat: classify agy model-unavailable as exit 14 (agy 1.1.2) + upstream notes (0.18.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.18.1
+- **New structured failure `14` — model unavailable** (agy 1.1.2): agy now **hard-fails**
+  (instead of silently downgrading to the default model) when `--model` can't be resolved.
+  The wrapper classifies this into exit `14` + `AGY_SIGNAL {MODEL_UNAVAILABLE}` and prints
+  an actionable hint (run `agy models`; fix `--model` / `tier_*` / `default_model`) — the
+  common failure when a tier remap points at a model your plan doesn't expose. `agy-job`
+  renders the new code.
+- **Note on agy 1.1.x upstream fixes** (verified against release notes): 1.1.1 fixed
+  `agy -p` hanging inside a subprocess/script and print mode silently exiting success on a
+  server-side error; both are now non-zero + stderr, so the wrapper classifies them
+  correctly. Native Windows headless (`#508`/`#6`) is **still not resolved upstream**, and
+  `--output-format json` is **still not externally available** — the WSL guidance and
+  plain-text parsing stay.
+
 ## 0.18.0
 - **agy 1.1.0 support — `--mode accept-edits|plan` passthrough** (all behaviors below
   verified live on 1.1.0):

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -98,6 +98,7 @@ On classifiable failures the wrapper prints a machine-readable line to stderr:
 | 11 | not authenticated | run `agy` once interactively to sign in |
 | 12 | timeout (agy's own, or the wall-clock guard) | raise `--timeout`, narrow the task; on Windows see the hang section above |
 | 13 | agy not on PATH | install the Antigravity CLI |
+| 14 | model unavailable | the `--model` / `tier_*` / `default_model` name isn't in `agy models` (agy ≥ 1.1.2 hard-fails instead of silently downgrading) — run `agy models` and fix the name |
 
 ---
 

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -37,7 +37,8 @@
 #       --print-command              Print the resolved agy command and exit (dry run)
 #   -h, --help                       Show this help
 #
-# Exit codes: 0 ok | 1 usage | 2 agy failed | 3 empty | 10 quota | 11 auth | 12 timeout | 13 agy missing
+# Exit codes: 0 ok | 1 usage | 2 agy failed | 3 empty | 10 quota | 11 auth | 12 timeout
+#             | 13 agy missing | 14 model unavailable (--model / tier remap not in `agy models`)
 #
 # On a classifiable failure, a machine-readable line is printed to stderr so
 # orchestrators (e.g. agy-job.sh) can react without scraping prose:
@@ -301,6 +302,13 @@ if [ $RC -ne 0 ]; then
       shopt -u nocasematch; signal AUTH_REQUIRED "agy not authenticated — run \`agy\` once"; exit 11 ;;
     *"timed out"*|*"deadline exceeded"*|*"print-timeout"*)
       shopt -u nocasematch; signal TIMEOUT "agy print-timeout / deadline exceeded"; exit 12 ;;
+    *"invalid --model"*|*"is not recognized as a known model"*|*"not a known model"*)
+      # agy >= 1.1.2 hard-fails (instead of silently downgrading) when --model can't be
+      # resolved — common when a tier_* / default_model remap points at a model this plan
+      # doesn't expose. Surface it as its own actionable category.
+      shopt -u nocasematch
+      echo "agy-delegate: model '$MODEL' is not available on this plan — run \`agy models\`, then fix --model / the tier_* / default_model option." >&2
+      signal MODEL_UNAVAILABLE "model not in \`agy models\` (check --model / tier remaps)"; exit 14 ;;
   esac
   shopt -u nocasematch
   signal AGY_FAILED "agy exited $RC"

--- a/scripts/agy-job.sh
+++ b/scripts/agy-job.sh
@@ -55,6 +55,7 @@ rc_label() {
     11) echo 'AUTH required — run `agy` once interactively' ;;
     12) echo 'TIMEOUT — raise --timeout or narrow scope' ;;
     13) echo 'agy MISSING — install the Antigravity CLI' ;;
+    14) echo 'MODEL unavailable — check `agy models` / tier remap' ;;
     *)  echo 'error' ;;
   esac
 }

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.18.0
+version: 0.18.1
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -80,9 +80,11 @@ the unit to the **`antigravity-delegate` subagent** (its only file-acting tool i
 wrapper; it returns a digest for you to verify). Either way, *you* still own verification.
 
 **Structured failures.** The wrapper exits `10` quota · `11` auth · `12` timeout · `13`
-agy-missing (besides `2` failed / `3` empty) and prints a `AGY_SIGNAL {...}` line on
-stderr; `agy-job status`/`result` surface it, so you can react (e.g. retry quota with
-`--continue`) instead of scraping prose.
+agy-missing · `14` model-unavailable (a `--model` / `tier_*` / `default_model` name not in
+`agy models` — agy ≥ 1.1.2 hard-fails instead of silently downgrading) (besides `2` failed
+/ `3` empty) and prints a `AGY_SIGNAL {...}` line on stderr; `agy-job status`/`result`
+surface it, so you can react (e.g. retry quota with `--continue`, or fix the model name)
+instead of scraping prose.
 
 **If Claude itself is running headless (`claude -p`, one-shot):** run delegations
 **synchronously** — let `agy-delegate` BLOCK and return before you continue. Do NOT

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -26,6 +26,7 @@ case "${STUB_MODE:-text}" in
   quota)   echo "Error: quota exceeded for this model" >&2; exit 1 ;;     # -> wrapper exit 10
   auth)    echo "Error: request is unauthenticated; please sign in" >&2; exit 1 ;; # -> exit 11
   timeout) echo "Error: deadline exceeded (the request timed out)" >&2; exit 1 ;;  # -> exit 12
+  badmodel) echo "Error: invalid --model \"X\": model X is not recognized as a known model" >&2; exit 1 ;; # -> exit 14
   big)     printf 'x%.0s' $(seq 1 20000); echo ;;    # dump-sized reply -> digest guard warns
   *)       echo "STUB_OK" ;;
 esac
@@ -107,6 +108,9 @@ check "agy auth -> exit 11 + signal" 11 "$rc" "AUTH_REQUIRED" "$out"
 
 out=$(STUB_MODE=timeout "$DELEGATE" "hi" 2>&1); rc=$?
 check "agy timeout -> exit 12 + signal" 12 "$rc" "TIMEOUT" "$out"
+
+out=$(STUB_MODE=badmodel "$DELEGATE" "hi" 2>&1); rc=$?
+check "agy bad --model -> exit 14 + signal" 14 "$rc" "MODEL_UNAVAILABLE" "$out"
 
 # wall-clock guard: a HANGING agy (sleeps far past the timeout) must be killed and
 # mapped to TIMEOUT (exit 12), not hang the wrapper forever (issue #6). Requires a


### PR DESCRIPTION
Triage + small robustness pass for **agy 1.1.1 / 1.1.2**. Most of what those releases changed is good news for us (upstream fixed things we were working around); one behavior change is worth classifying.

## The behavior change — model-unavailable now hard-fails

agy 1.1.2 **hard-fails** (non-zero + lists available models) when `--model` can't be resolved, instead of silently downgrading to the default model. Common trigger: a `tier_*` / `default_model` remap pointing at a model the plan doesn't expose — previously it ran on Gemini's default silently ("why isn't it cheaper / why does it behave differently?").

**Fix:** the wrapper classifies this into **exit `14` + `AGY_SIGNAL {MODEL_UNAVAILABLE}`** with an actionable hint (run `agy models`; fix `--model` / `tier_*` / `default_model`). `agy-job` renders the new code; SKILL + TROUBLESHOOTING exit tables updated.

Verified **live on agy 1.1.2** (bad `--model` → wrapper exit 14 + signal + hint) and via a stub test.

## Good news recorded (no code needed)

- 1.1.1 fixed `agy -p` hanging inside a subprocess/script, and print mode silently exiting *success* on a server-side error — both are now non-zero + stderr, so the wrapper classifies them correctly.
- 1.1.1 fixed a parallel-subagent data race → the internal fan-out recipe is more reliable.

## Still unresolved upstream (guidance unchanged)

- **Native Windows headless** hang ([#508](https://github.com/google-antigravity/antigravity-cli/issues/508) / our #6) — no explicit fix in 1.1.1/1.1.2. WSL guidance stays.
- **`--output-format json`** — still not externally available. Plain-text parsing stays.

## Verification
- **120 tests pass** (+1: bad `--model` → exit 14) · shellcheck clean · `claude plugin validate` passes
- Version `0.18.1`, SKILL/plugin.json in sync