### PR TITLE
feat: agy 1.1.3 write model — exit 15 permission-denied + --yolo as durable grant (0.18.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.18.2
+- **agy 1.1.3: headless write model changed again — `--yolo` is now the durable grant.**
+  All verified live on 1.1.3:
+  - 1.1.3 **removes the scratch-divert**: a write/tool needing permission is now
+    **soft-denied** in headless mode with a clear stderr notice (rc=0 + empty stdout).
+    This is the upstream's intended behavior (announced), not a bug — the evolved issue #10.
+  - **`--mode accept-edits` no longer grants headless writes** (soft-denied for create AND
+    edit on 1.1.3 — it had been riding the auto-approve behavior that 1.1.3 closed). Docs,
+    the `delegate` command, and the write-task warning now point to **`--yolo`** as the
+    reliable headless write/tool grant across versions; `--mode` passthrough stays but is
+    no longer recommended for writes.
+  - **New structured failure `15` — permission denied**: the wrapper detects the soft-deny
+    stderr (rc=0 + empty) and returns exit `15` + `AGY_SIGNAL {PERMISSION_DENIED}` with an
+    actionable message ("add `--yolo`"), instead of a bare "empty output". `agy-job`
+    renders it.
+  - Note: `--output-format json` is **still not externally available**, and native Windows
+    headless (`#508`/`#6`) is **still unresolved** — WSL guidance and plain-text parsing stay.
+
 ## 0.18.1
 - **New structured failure `14` — model unavailable** (agy 1.1.2): agy now **hard-fails**
   (instead of silently downgrading to the default model) when `--model` can't be resolved.

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ scripts/agy-delegate.sh --tier pro --dir ./src "List every TODO with file:line"
 # bulk read -> digest-only reply (the biggest cost lever; wrapper warns on dump-sized replies)
 scripts/agy-delegate.sh --digest --dir . "Map the auth flow end to end"
 
-# write task: auto-apply FILE edits without granting terminal/tools (agy >= 1.1.0)
-scripts/agy-delegate.sh --mode accept-edits --dir ./app "Implement X per SPEC.md"
+# write task: --yolo is the reliable headless write grant (run on a branch; verify git status)
+scripts/agy-delegate.sh --yolo --dir ./app "Implement X per SPEC.md"
 
 # live web / Google search (tools need --yolo in headless mode)
 scripts/agy-delegate.sh --tier pro --yolo "Web-search <X>. Give URLs + dates."
@@ -167,7 +167,7 @@ Delegation doesn't save money by itself — these do (also in the skill):
 **Known limits (agy v1.0.x)**
 - `-p`/`--print` **takes the prompt as its value** and must come last — the wrapper handles this.
 - No `--output-format json` (plain text); `--print` drops stdout on a non-TTY unless stdin is detached (handled via `< /dev/null`).
-- **Writes need write permission:** without it, headless agy describes the edits or (agy ≥ 1.1.0, review-first default) writes them to its **own scratch dir** — your workspace stays untouched while agy reports success ([issue #10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)). Prefer **`--mode accept-edits`** (agy ≥ 1.1.0; file edits only, no terminal/tool grant); use `--yolo` when the task also needs tools (web / Vertex AI Search). Run write tasks on a branch and verify files actually changed. Long write tasks can exceed the ~2-min sync Bash limit → use a background job.
+- **Writes need `--yolo`:** headless agy's no-permission behavior keeps shifting (describe-only pre-1.1.0 · scratch-divert 1.1.0–1.1.2 · soft-deny 1.1.3+), but every version leaves **your workspace untouched while the run still "succeeds"** ([issue #10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)). The durable grant is **`--yolo`** (`--dangerously-skip-permissions`) — `--mode accept-edits` only wrote headless on 1.1.0–1.1.2. Run write tasks on a branch and verify with `git status`; the wrapper maps a 1.1.3 soft-deny to exit `15`. Long write tasks can exceed the ~2-min sync Bash limit → use a background job.
 - **Native Windows (no ConPTY):** headless `agy -p` / `agy models` can hard-hang with a 0-byte log when stdio is redirected ([issue #6](https://github.com/yuting0624/antigravity-for-claude-code/issues/6)). The wrapper wraps agy in a wall-clock `timeout`/`gtimeout` guard so it returns a structured TIMEOUT (exit 12) instead of hanging; `doctor` reports the likely hang instead of a misleading "not authenticated". Without `timeout` on PATH there's no safety net — use **WSL/macOS/Linux** for headless delegation.
 - **WSL:** running agy with `--add-dir` on a Windows mount (`/mnt/c/...`) is very slow — agy reads the workspace over a 9p bridge, so even trivial calls can take 20s+. Keep the repo on the WSL Linux filesystem (`~`). The wrapper and `doctor` warn about this.
 

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -11,19 +11,18 @@ Task: $ARGUMENTS
 Do this:
 1. Pick a tier (`flash` default; `pro` for hard reasoning). If the task needs the repo,
    add `--dir <repo-root>` so agy reads the real files (don't paste them into context).
-   **If the task WRITES files**, grant write permission — without it, headless agy
-   describes the edits or writes them to its **own scratch dir**, NOT your workspace,
-   while still reporting success (issue #10):
-   - Pure file writes (implement / scaffold / test-gen / migrate / fix): **`--mode
-     accept-edits`** (agy ≥ 1.1.0) — auto-applies edits *without* granting terminal/tool
-     permissions. Prefer this.
-   - Task also needs tools (web / Vertex AI Search / terminal): **`--yolo`**. Claude Code
-     may prompt for or block `--dangerously-skip-permissions` — approve it when asked, or
-     pre-allow it; non-interactive (`claude -p`) without that permission can't use tools via agy.
-   - Either way: run write tasks on a dedicated branch (+ `--sandbox`), and **verify files
-     actually changed in the workspace** (`git status`).
+   **If the task WRITES files or uses tools** (web / Vertex AI Search / terminal), pass
+   **`--yolo`** — the reliable headless write/tool grant across agy versions. Without it,
+   headless agy leaves your workspace untouched while still reporting success (it
+   describes / scratch-diverts / soft-denies depending on version; issue #10). `--mode
+   accept-edits` is NOT a dependable substitute — it only wrote headless on agy 1.1.0–1.1.2
+   and is soft-denied on 1.1.3. Run write tasks on a dedicated branch (+ `--sandbox`), and
+   **verify files actually changed** with `git status`. Claude Code may prompt for or block
+   `--dangerously-skip-permissions` — approve it or pre-allow it; non-interactive
+   (`claude -p`) without that permission can't write/use-tools via agy. (If the wrapper
+   returns exit `15`, that's exactly this: agy soft-denied the write — add `--yolo`.)
 2. Run **synchronously** (you may be headless — do not background-and-wait):
-   `agy-delegate --tier <tier> [--dir .] [--mode accept-edits | --yolo] [--digest] "<task>"`
+   `agy-delegate --tier <tier> [--dir .] [--yolo] [--digest] "<task>"`
    For read/analysis tasks, add `--digest` — it appends a digest-only output contract so
    agy returns compact bullets instead of raw content.
 3. Ingest only the **result/digest** — do NOT re-read the files agy already handled

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -59,24 +59,23 @@ wrapper and `agy-doctor` warn when they detect this.
 
 ## agy says "done" but wrote no files (or wrote them somewhere else)
 
-**Cause:** write tasks need write permission. Without it, headless agy either only
-*describes* the edits (pre-1.1.0) or — since agy 1.1.0's review-first default — writes
-them to its **own scratch dir** (`~/.gemini/antigravity-cli/scratch/`), **not your
-workspace**, and still returns success
-([#10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)). The wrapper
-warns when a write-looking prompt lacks write permission.
+**Cause:** write tasks need write permission, and headless agy's no-permission behavior
+has changed across versions — but in every case **your workspace stays untouched while the
+run still "succeeds"** ([#10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)):
+- pre-1.1.0: only *describes* the edits
+- 1.1.0–1.1.2: writes to its **own scratch dir** (`~/.gemini/antigravity-cli/scratch/`)
+- 1.1.3+: **soft-denies** the write and prints a stderr notice naming the allow-rule
 
 **Fix:**
-- **Pure file writes** (implement / scaffold / test-gen / migrate): pass
-  **`--mode accept-edits`** (agy ≥ 1.1.0) — auto-applies edits to the real workspace
-  *without* granting terminal/tool permissions (a narrower grant than `--yolo`; prefer it).
-- **Task also uses tools** (web / Vertex AI Search / terminal): pass `--yolo`
-  (`--dangerously-skip-permissions`). Claude Code may prompt for (or in auto-mode, block)
-  it — approve it, or pre-allow `Bash(agy-delegate*)` in your permission settings.
+- **Pass `--yolo`** (`--dangerously-skip-permissions`) — the one write/tool grant that
+  works headless across all agy versions. (`--mode accept-edits` only wrote headless on
+  1.1.0–1.1.2 and is soft-denied on 1.1.3 — don't rely on it.)
+- Claude Code may prompt for (or in auto-mode, block) `--dangerously-skip-permissions` —
+  approve it, or pre-allow `Bash(agy-delegate*)` in your permission settings.
 - Run write tasks on a **dedicated branch** (add `--sandbox` for containment).
 - **Always verify files actually changed in your workspace** (`git status`) — never trust
-  the self-report. If agy claims success but the repo is clean, look in
-  `~/.gemini/antigravity-cli/scratch/`.
+  the self-report. The wrapper maps a 1.1.3 soft-deny to **exit 15** so you get an
+  actionable message instead of a bare "empty output".
 - Long write tasks can exceed Claude Code's ~2-min synchronous Bash limit → run them as a
   background job: `ID=$(agy-job start --tier pro --dir . "<task>")`, then
   `/antigravity:status` / `/antigravity:result <id>` (interactive sessions only).
@@ -99,6 +98,7 @@ On classifiable failures the wrapper prints a machine-readable line to stderr:
 | 12 | timeout (agy's own, or the wall-clock guard) | raise `--timeout`, narrow the task; on Windows see the hang section above |
 | 13 | agy not on PATH | install the Antigravity CLI |
 | 14 | model unavailable | the `--model` / `tier_*` / `default_model` name isn't in `agy models` (agy ≥ 1.1.2 hard-fails instead of silently downgrading) — run `agy models` and fix the name |
+| 15 | permission denied | agy ≥ 1.1.3 soft-denied a tool needing permission in headless mode (e.g. a file write) — pass `--yolo` and run on a branch |
 
 ---
 

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -39,6 +39,7 @@
 #
 # Exit codes: 0 ok | 1 usage | 2 agy failed | 3 empty | 10 quota | 11 auth | 12 timeout
 #             | 13 agy missing | 14 model unavailable (--model / tier remap not in `agy models`)
+#             | 15 permission denied (agy >= 1.1.3 soft-denied a permissioned tool headless — pass --yolo)
 #
 # On a classifiable failure, a machine-readable line is printed to stderr so
 # orchestrators (e.g. agy-job.sh) can react without scraping prose:
@@ -202,16 +203,17 @@ if on_wsl; then
   done
 fi
 
-# Heads-up: a likely write task without write permission. Headless agy without
-# --mode accept-edits / --yolo either only DESCRIBES edits (pre-1.1.0) or writes them
-# to its OWN scratch dir (~/.gemini/antigravity-cli/scratch, 1.1.0 review-first default)
-# — either way YOUR WORKSPACE IS UNTOUCHED while agy reports success (issue #10).
+# Heads-up: a likely write task without write permission. Headless agy's write behavior
+# has shifted across versions (describe-only pre-1.1.0; scratch-divert 1.1.0-1.1.2;
+# soft-deny with a stderr notice on 1.1.3) — but the one durable grant is --yolo. Without
+# it, YOUR WORKSPACE IS UNTOUCHED (issue #10). (--mode accept-edits worked headless only on
+# 1.1.0-1.1.2 and is soft-denied on 1.1.3, so it no longer suppresses this warning.)
 # Best-effort heuristic; warn only. --print-command (dry run) is exempt.
-if [ "$YOLO" -eq 0 ] && [ "$MODE" != "accept-edits" ] && [ "$PRINT_CMD" -ne 1 ]; then
+if [ "$YOLO" -eq 0 ] && [ "$PRINT_CMD" -ne 1 ]; then
   shopt -s nocasematch
   case "$PROMPT" in
     *implement*|*scaffold*|*migrate*|*refactor*|*"write the file"*|*"create the file"*|*"edit the file"*)
-      echo "agy-delegate: note: this looks like a write task but neither --mode accept-edits nor --yolo is set — headless agy will describe the edits or write them to its own scratch dir, NOT your workspace, while still reporting success (issue #10). Use --mode accept-edits for pure file writes (agy >= 1.1.0), or --yolo when the task also needs tools (web/terminal); run write tasks on a branch." >&2 ;;
+      echo "agy-delegate: note: this looks like a write task but --yolo is not set — headless agy will NOT write to your workspace without it (it describes / scratch-diverts / soft-denies depending on version, while the run still 'succeeds'; issue #10). Add --yolo and run on a dedicated branch, then verify with git status." >&2 ;;
   esac
   shopt -u nocasematch
 fi
@@ -315,6 +317,20 @@ if [ $RC -ne 0 ]; then
   exit 2
 fi
 if [ -z "${OUT//[$' \t\n\r']/}" ]; then
+  # agy >= 1.1.3 soft-denies a tool needing permission in headless mode and returns
+  # rc=0 with EMPTY stdout plus an explanatory stderr notice (the evolved issue #10:
+  # earlier versions silently wrote to a scratch dir or only described the edit). Detect
+  # it so the caller gets an actionable signal instead of a bare "empty output".
+  eblob="$(cat "$ERR" 2>/dev/null)"
+  shopt -s nocasematch
+  case "$eblob" in
+    *"auto-denied"*|*"permissions.allow"*|*"permission that headless"*|*"dangerously-skip-permissions"*)
+      shopt -u nocasematch
+      [ -s "$ERR" ] && cat "$ERR" >&2
+      echo "agy-delegate: agy soft-denied a tool that needs permission (headless can't prompt) — no work was done. For file writes add --yolo (run on a branch); tool use (web/Vertex/terminal) also needs --yolo. (agy >= 1.1.3)" >&2
+      signal PERMISSION_DENIED "agy soft-denied a permissioned tool in headless — pass --yolo"; exit 15 ;;
+  esac
+  shopt -u nocasematch
   echo "agy-delegate: agy returned empty output (model='$MODEL')" >&2
   exit 3
 fi

--- a/scripts/agy-job.sh
+++ b/scripts/agy-job.sh
@@ -56,6 +56,7 @@ rc_label() {
     12) echo 'TIMEOUT — raise --timeout or narrow scope' ;;
     13) echo 'agy MISSING — install the Antigravity CLI' ;;
     14) echo 'MODEL unavailable — check `agy models` / tier remap' ;;
+    15) echo 'PERMISSION denied — pass --yolo for writes/tools (agy >= 1.1.3)' ;;
     *)  echo 'error' ;;
   esac
 }

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.18.1
+version: 0.18.2
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -61,10 +61,11 @@ the cross-model verification value (Claude executing Claude loses both).
 agy-delegate [options] "the task prompt"
 ```
 Options: `--tier flash|flash-lo|pro` · `--dir <path>` (workspace, repeatable) ·
-`--timeout 10m` · `--mode accept-edits|plan` (agy ≥ 1.1.0 — `accept-edits` auto-applies
-FILE EDITS to the workspace *without* granting terminal/tools: the safer choice for pure
-write tasks; `plan` touches nothing) · `--yolo` (auto-approve ALL tools — needed for
-web/terminal use in headless mode; broader than `--mode accept-edits`) · `--sandbox` ·
+`--timeout 10m` · `--yolo` (auto-approve ALL tools — the reliable headless grant for **any
+file write or tool use**; run write tasks on a branch) · `--mode accept-edits|plan`
+(agy execution mode: `accept-edits` auto-applied file edits headless on 1.1.0–1.1.2 but is
+**soft-denied on 1.1.3** — no longer a dependable headless write grant, use `--yolo`;
+`plan` = strategize only) · `--sandbox` ·
 `--digest` (append a digest-only output contract — use it for any
 bulk read/analysis; the wrapper also warns on stderr when a reply comes back dump-sized,
 because ingesting digests instead of dumps is the single biggest cost lever) ·
@@ -81,10 +82,11 @@ wrapper; it returns a digest for you to verify). Either way, *you* still own ver
 
 **Structured failures.** The wrapper exits `10` quota · `11` auth · `12` timeout · `13`
 agy-missing · `14` model-unavailable (a `--model` / `tier_*` / `default_model` name not in
-`agy models` — agy ≥ 1.1.2 hard-fails instead of silently downgrading) (besides `2` failed
-/ `3` empty) and prints a `AGY_SIGNAL {...}` line on stderr; `agy-job status`/`result`
-surface it, so you can react (e.g. retry quota with `--continue`, or fix the model name)
-instead of scraping prose.
+`agy models` — agy ≥ 1.1.2 hard-fails instead of silently downgrading) · `15`
+permission-denied (agy ≥ 1.1.3 soft-denies a permissioned tool headless — pass `--yolo`)
+(besides `2` failed / `3` empty) and prints a `AGY_SIGNAL {...}` line on stderr;
+`agy-job status`/`result` surface it, so you can react (e.g. retry quota with `--continue`,
+fix the model name, or add `--yolo`) instead of scraping prose.
 
 **If Claude itself is running headless (`claude -p`, one-shot):** run delegations
 **synchronously** — let `agy-delegate` BLOCK and return before you continue. Do NOT
@@ -139,15 +141,15 @@ If wrong: retry on `--tier pro`, sharpen the spec, or do that piece yourself.
 
 Read-only work (search, review, analysis) is low-risk. **When agy writes files or runs
 commands** (`--yolo` grants write + terminal):
-- **Write tasks MUST grant write permission.** Without it, headless agy describes the
-  edits (pre-1.1.0) or writes them to its **own scratch dir** (`~/.gemini/antigravity-cli/scratch`,
-  1.1.0 review-first default) — your workspace stays untouched while agy reports success
-  (issue #10). Prefer **`--mode accept-edits`** (agy ≥ 1.1.0, file edits only — no
-  terminal/tool grant); use **`--yolo`** only when the task also needs tools (web /
-  Vertex AI Search / terminal). Claude Code may prompt for or block
-  `--dangerously-skip-permissions` — approve it or pre-allow `Bash(agy-delegate*)`.
-  Always verify files actually changed **in the workspace** (the gate catches the
-  silent no-write / scratch divert).
+- **Write tasks MUST pass `--yolo`.** Headless agy's no-permission behavior has shifted
+  every few releases — describe-only (pre-1.1.0), scratch-divert (1.1.0–1.1.2), soft-deny
+  with a stderr notice (1.1.3) — but in every version **your workspace stays untouched
+  while the run still "succeeds"** (issue #10). The one durable write grant is `--yolo`
+  (`--dangerously-skip-permissions`). (`--mode accept-edits` only wrote headless on
+  1.1.0–1.1.2 and is soft-denied on 1.1.3 — don't rely on it for writes.) Claude Code may
+  prompt for or block `--dangerously-skip-permissions` — approve it or pre-allow
+  `Bash(agy-delegate*)`. Always verify files actually changed **in the workspace** with
+  `git status` (the wrapper maps a 1.1.3 soft-deny to exit `15` so you're not left guessing).
 - Run it on a **dedicated git branch or worktree** so changes are isolated.
 - Add `--sandbox` for execution containment.
 - **Claude reviews the diff before merging** — never auto-merge agy's writes.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -27,6 +27,7 @@ case "${STUB_MODE:-text}" in
   auth)    echo "Error: request is unauthenticated; please sign in" >&2; exit 1 ;; # -> exit 11
   timeout) echo "Error: deadline exceeded (the request timed out)" >&2; exit 1 ;;  # -> exit 12
   badmodel) echo "Error: invalid --model \"X\": model X is not recognized as a known model" >&2; exit 1 ;; # -> exit 14
+  softdeny) echo "no output produced — a tool required the \"write_file\" permission that headless mode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow" >&2; exit 0 ;; # rc=0 + empty stdout -> exit 15
   big)     printf 'x%.0s' $(seq 1 20000); echo ;;    # dump-sized reply -> digest guard warns
   *)       echo "STUB_OK" ;;
 esac
@@ -112,6 +113,10 @@ check "agy timeout -> exit 12 + signal" 12 "$rc" "TIMEOUT" "$out"
 out=$(STUB_MODE=badmodel "$DELEGATE" "hi" 2>&1); rc=$?
 check "agy bad --model -> exit 14 + signal" 14 "$rc" "MODEL_UNAVAILABLE" "$out"
 
+# agy >= 1.1.3: permissioned tool soft-denied headless -> rc=0 + empty stdout + stderr notice
+out=$(STUB_MODE=softdeny "$DELEGATE" "implement it" 2>&1); rc=$?
+check "agy soft-deny (no permission) -> exit 15 + signal" 15 "$rc" "PERMISSION_DENIED" "$out"
+
 # wall-clock guard: a HANGING agy (sleeps far past the timeout) must be killed and
 # mapped to TIMEOUT (exit 12), not hang the wrapper forever (issue #6). Requires a
 # real `timeout`/`gtimeout`; skip cleanly if neither is on PATH.
@@ -165,17 +170,19 @@ check "--print-command shows the tier model" 0 "$rc" "Pro" "$out"
 out=$(PATH="/usr/bin:/bin" "$DELEGATE" --print-command "hi" 2>/dev/null); rc=$?
 check "--print-command works without agy on PATH" 0 "$rc" "--print-timeout" "$out"
 
-# write-task without write permission -> warn (describe-only pre-1.1.0, scratch-divert on 1.1.0) (issue #10)
+# write-task without --yolo -> warn (workspace untouched; issue #10). The one durable
+# grant is --yolo; --mode accept-edits stopped granting headless writes on agy 1.1.3.
+WARN='NOT write to your workspace'
 out=$(STUB_MODE=args "$DELEGATE" "implement the parser module" 2>&1); rc=$?
-check "write prompt w/o write permission -> warns" 0 "$rc" "scratch dir" "$out"
+check "write prompt w/o --yolo -> warns" 0 "$rc" "$WARN" "$out"
 out=$(STUB_MODE=args "$DELEGATE" --yolo "implement the parser module" 2>&1); rc=$?
-if printf '%s' "$out" | grep -q "scratch dir"; then echo "FAIL: warned even with --yolo"; FAIL=$((FAIL+1));
+if printf '%s' "$out" | grep -qF "$WARN"; then echo "FAIL: warned even with --yolo"; FAIL=$((FAIL+1));
 else echo "ok: no write-warning when --yolo is set"; PASS=$((PASS+1)); fi
 out=$(STUB_MODE=args "$DELEGATE" --mode accept-edits "implement the parser module" 2>&1); rc=$?
-if printf '%s' "$out" | grep -q "scratch dir"; then echo "FAIL: warned even with --mode accept-edits"; FAIL=$((FAIL+1));
-else echo "ok: no write-warning with --mode accept-edits"; PASS=$((PASS+1)); fi
+if printf '%s' "$out" | grep -qF "$WARN"; then echo "ok: --mode accept-edits still warns (soft-denied on 1.1.3)"; PASS=$((PASS+1));
+else echo "FAIL: no warning with --mode accept-edits (should warn since 1.1.3)"; FAIL=$((FAIL+1)); fi
 out=$(STUB_MODE=args "$DELEGATE" "summarize the changelog in 3 bullets" 2>&1); rc=$?
-if printf '%s' "$out" | grep -q "scratch dir"; then echo "FAIL: warned for a non-write prompt"; FAIL=$((FAIL+1));
+if printf '%s' "$out" | grep -qF "$WARN"; then echo "FAIL: warned for a non-write prompt"; FAIL=$((FAIL+1));
 else echo "ok: no write-warning for a read/summary prompt"; PASS=$((PASS+1)); fi
 
 # --mode passthrough (agy >= 1.1.0): accept-edits reaches agy; invalid mode errors early


### PR DESCRIPTION
Tracks **agy 1.1.3**, which changed the headless write model again. All behaviors below verified live on 1.1.3.

## What changed upstream (the evolved #10)

agy 1.1.3 **removes the scratch-divert**. A write/tool that needs permission is now **soft-denied** in headless mode (rc=0 + empty stdout + a clear stderr notice naming the allow-rule). This is upstream's *announced* behavior, not a bug — and a real improvement over the deceptive scratch-divert.

Two consequences for us:
- **`--mode accept-edits` no longer grants headless writes** — soft-denied for create AND edit on 1.1.3 (it had been riding the auto-approve behavior 1.1.3 closed). Our v0.18.0 "prefer accept-edits" guidance is now wrong.
- Through the wrapper, a soft-deny landed as a bare **exit 3 "empty output"**, hiding the cause.

## Changes

- **New structured failure `15` — permission denied.** The wrapper detects the soft-deny stderr (rc=0 + empty + `auto-denied` / `permissions.allow` / `dangerously-skip-permissions`) → exit `15` + `AGY_SIGNAL {PERMISSION_DENIED}` + an actionable *"add `--yolo`"* message. `agy-job` renders it.
- **`--yolo` is now the documented durable write/tool grant** (the one path that works headless across every agy version). README / SKILL / `delegate` command / TROUBLESHOOTING updated; the write-task warning keys on `--yolo` only. `--mode` passthrough stays but is no longer recommended for writes.

## Still unresolved upstream (guidance unchanged)
- `--output-format json` — still not externally available (plain-text parsing stays).
- Native Windows headless ([#508](https://github.com/google-antigravity/antigravity-cli/issues/508) / our #6) — no fix in 1.1.3 (WSL guidance stays).

## Verification
- **121 tests pass** (+1: soft-deny → exit 15; write-warning tests updated) · shellcheck clean · `claude plugin validate` passes
- **Live on agy 1.1.3**: no-permission write through the wrapper → exit 15 + signal + workspace untouched ✓