### PR TITLE
fix: doctor recognizes tier models across agy 1.1.5 slug format; verify 1.1.5 + Gemini 3.6 (0.18.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.18.3
+- **`doctor` fix — recognize tier models across `agy models` format changes.** agy 1.1.5
+  switched `agy models` output from **display names** (`Gemini 3.5 Flash (High)`) to
+  **slugs** (`gemini-3.5-flash`), which broke doctor's strict `grep` and made it **falsely
+  warn that every tier model was missing** (they still work). doctor now normalizes both
+  sides (lowercase-alphanumeric, bidirectional substring), so it survives either format.
+- **Verified against agy 1.1.4 / 1.1.5.** Default `flash` delegation, tier resolution, and
+  exit-code classification all work on 1.1.5 (1.1.4/1.1.5 were mostly interactive/UX:
+  `--effort`, stable model slugs, `/model` picker, MCP fixes).
+- **Gemini 3.6 Flash** now appears in `agy models` and **works** (verified all effort
+  variants through the wrapper). The `flash` **default stays Gemini 3.5 Flash (High)** for
+  broad plan availability (newer models can lag on enterprise Vertex) — remap `tier_flash`
+  to `Gemini 3.6 Flash (High)` if your plan serves it. (Both display names and 1.1.5 slugs
+  are accepted by `--model`.)
+- **Still unchanged upstream** (re-confirmed on 1.1.5): headless writes need `--yolo` (a
+  `permissions.allow` write-rule was still soft-denied in testing despite 1.1.4's
+  "honor settings.json headless"), `--output-format json` not externally available yet,
+  native Windows headless (`#508`/`#6`) unresolved.
+
 ## 0.18.2
 - **agy 1.1.3: headless write model changed again — `--yolo` is now the durable grant.**
   All verified live on 1.1.3:

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ via plugin options — `default_model`, or per-tier `tier_flash` / `tier_flash_l
 (env `CLAUDE_PLUGIN_OPTION_*`). Keep the executor a *different, cheaper* model than the Claude
 conductor — that's what gives both the cost saving and the cross-model verification.
 
+> **Verified through agy 1.1.5.** A newer **Gemini 3.6 Flash** now shows up in `agy models` and works — the `flash` default stays on **Gemini 3.5 Flash (High)** for broad plan availability (newer models can lag on enterprise Vertex); remap `tier_flash` to `Gemini 3.6 Flash (High)` when your plan serves it. (agy 1.1.5 switched `agy models` to slugs like `gemini-3.5-flash`; both slugs and display names work with `--model`, and `doctor` matches either.)
+
 </details>
 
 <details>

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -12,6 +12,26 @@ warn() { printf '  ⚠ %s\n' "$*"; }   # advisory; does NOT fail the check
 info() { printf '    %s\n' "$*"; }
 FAIL=0
 
+# Normalize a model id to lowercase alphanumerics only, so a configured display name
+# ("Gemini 3.5 Flash (High)") and an `agy models` entry survive comparison regardless of
+# format. agy 1.1.5 switched `agy models` output from display names to slugs
+# (`gemini-3.5-flash`), which broke a strict grep and made doctor falsely warn that every
+# tier model was missing (they still worked). Both forms normalize to a comparable core.
+norm_model() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]'; }
+# True if $1 (a configured tier model) matches any line in $MODELS, in either direction
+# (a slug is a substring of the display name, or vice versa).
+model_present() {
+  local want line n; want="$(norm_model "$1")"; [ -n "$want" ] || return 1
+  while IFS= read -r line; do
+    n="$(norm_model "$line")"; [ -n "$n" ] || continue
+    case "$want" in *"$n"*) return 0 ;; esac
+    case "$n" in *"$want"*) return 0 ;; esac
+  done <<EOF
+$MODELS
+EOF
+  return 1
+}
+
 # Resolve a usable `timeout` command (GNU coreutils, or macOS Homebrew gtimeout)
 # so a headless/no-TTY hang in `agy models` is bounded instead of freezing doctor.
 TO_CMD=""
@@ -80,7 +100,7 @@ if command -v agy >/dev/null 2>&1; then
     FLASH_LO="${CLAUDE_PLUGIN_OPTION_TIER_FLASH_LO:-Gemini 3.5 Flash (Low)}"
     PRO="${CLAUDE_PLUGIN_OPTION_TIER_PRO:-Gemini 3.1 Pro (High)}"
     for m in "$FLASH" "$FLASH_LO" "$PRO"; do
-      if printf '%s' "$MODELS" | grep -qF "$m"; then
+      if model_present "$m"; then
         ok "tier model present: $m"
       else
         warn "tier model not in 'agy models': $m"

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.18.2
+version: 0.18.3
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -54,6 +54,13 @@ model `agy models` lists (Claude / GPT on plans that expose them) — via `--mod
 or persistently with the `default_model` / `tier_*` plugin options. Keep the executor a
 *different, cheaper* model than the Claude conductor: that's what yields the cost saving **and**
 the cross-model verification value (Claude executing Claude loses both).
+
+> **Model availability moves fast.** Verified through **agy 1.1.5**. A newer **Gemini 3.6 Flash**
+> now appears in `agy models` and works — but the `flash` default **stays on Gemini 3.5 Flash
+> (High)** for broad plan availability (newer models can lag on enterprise Vertex). Remap
+> `tier_flash` to `Gemini 3.6 Flash (High)` when your plan serves it. Note: agy 1.1.5 changed
+> `agy models` output to slugs (`gemini-3.5-flash`); both slugs and display names are accepted
+> by `--model`, and `doctor` matches either.
 
 ## How to call it
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -19,6 +19,12 @@ mkdir -p "$TMP/bin"
 cat > "$TMP/bin/agy" <<'STUB'
 #!/usr/bin/env bash
 [ -n "${STUB_SLEEP:-}" ] && sleep "$STUB_SLEEP"
+# `agy models` emits the slug format agy 1.1.5+ uses (was display names before) so doctor's
+# tier-model check is exercised against the current format.
+if [ "$1" = "models" ]; then
+  printf '%s\n' gemini-3.6-flash-high gemini-3.5-flash gemini-3.5-flash-low gemini-3.1-pro-high
+  exit 0
+fi
 case "${STUB_MODE:-text}" in
   empty)   exit 0 ;;                  # no stdout -> wrapper should exit 3
   fail)    echo "boom" >&2; exit 7 ;; # nonzero  -> wrapper should exit 2
@@ -392,6 +398,17 @@ case "$out" in *doctor*) echo "ok: bin/agy-doctor forwards to doctor.sh"; PASS=$
   *) echo "FAIL: bin/agy-doctor did not forward (got: '$out')"; FAIL=$((FAIL+1));; esac
 out=$(env -u CLAUDE_PLUGIN_ROOT "$BIN/cloud-debug" --service svc --print-command 2>/dev/null); rc=$?
 check "bin/cloud-debug forwards to cloud-debug.sh (no CLAUDE_PLUGIN_ROOT)" 0 "$rc" "logging read" "$out"
+
+echo "== doctor.sh tier-model check (agy 1.1.5 slug format) =="
+# The stub's `agy models` emits slugs (gemini-3.5-flash); doctor's default tier models are
+# display names (Gemini 3.5 Flash (High)). Regression guard: doctor must still recognize them.
+out=$(bash "$ROOT/scripts/doctor.sh" 2>&1)
+if printf '%s' "$out" | grep -q "tier model not in"; then
+  echo "FAIL: doctor falsely warns tier model missing against slug-format agy models"; FAIL=$((FAIL+1));
+else echo "ok: doctor recognizes tier models across display-name/slug formats"; PASS=$((PASS+1)); fi
+if printf '%s' "$out" | grep -q "tier model present: Gemini 3.5 Flash (High)"; then
+  echo "ok: doctor matches default flash tier in slug format"; PASS=$((PASS+1));
+else echo "FAIL: doctor did not confirm the default flash tier present"; FAIL=$((FAIL+1)); fi
 
 echo "== agy-trace.sh (subagent trajectory reader) =="
 TRACE="$ROOT/scripts/agy-trace.sh"


### PR DESCRIPTION
Checked agy 1.1.4 / 1.1.5 and the new Gemini 3.6 Flash. One real bug surfaced.

## The bug — doctor falsely warns every tier model is missing

agy 1.1.5 switched `agy models` output from **display names** (`Gemini 3.5 Flash (High)`) to **slugs** (`gemini-3.5-flash`). doctor's strict `grep` no longer matched, so `/antigravity:setup` reported **all three tier models "not in agy models"** — even though they work fine. Misleading for anyone (e.g. a customer running the trial) checking setup.

**Fix:** doctor now normalizes both sides (lowercase-alphanumeric, bidirectional substring) and matches **either format**. Verified live on 1.1.5 — all three tiers show "present". Added a regression test (stub `agy models` now emits slugs).

## Verified, no behavior change needed
- Default `flash` delegation, tier resolution, and exit-code classification all work on **agy 1.1.5** (1.1.4/1.1.5 were mostly interactive/UX: `--effort`, model slugs, `/model` picker, MCP fixes).
- **Gemini 3.6 Flash works** (all effort variants via the wrapper). The `flash` **default stays Gemini 3.5 Flash (High)** for broad plan availability — newer models can lag on enterprise Vertex; remap `tier_flash` to 3.6 when your plan serves it. (Both slugs and display names are accepted by `--model`.)

## Still unchanged upstream (re-confirmed on 1.1.5)
- Headless writes need `--yolo` (a `permissions.allow` write-rule was still soft-denied despite 1.1.4's "honor settings.json headless").
- `--output-format json` not externally available yet; native Windows headless ([#508](https://github.com/google-antigravity/antigravity-cli/issues/508) / #6) unresolved.

## Verification
- **123 tests pass** (+2: doctor recognizes tier models in slug format) · shellcheck clean · `claude plugin validate` passes.