### PR TITLE
feat: bin/measure-session shim so the cost tool works by bare name (0.18.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.18.4
+- **`bin/measure-session` shim** — `measure-session.py` was the only script without a `bin/`
+  entrypoint, so it couldn't be run by bare name from a marketplace install (only via the
+  `scripts/` path, which doesn't resolve from a user's own repo). It now has a shim like the
+  others, so `measure-session <session-id>` works on the PATH. (`doctor` + contract tests
+  cover it.)
+
 ## 0.18.3
 - **`doctor` fix — recognize tier models across `agy models` format changes.** agy 1.1.5
   switched `agy models` output from **display names** (`Gemini 3.5 Flash (High)`) to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to **Antigravity for Claude Code**. Format loosely follows
   `scripts/` path, which doesn't resolve from a user's own repo). It now has a shim like the
   others, so `measure-session <session-id>` works on the PATH. (`doctor` + contract tests
   cover it.)
+- **Fan-out recipe corrected for agy 1.1.3+.** The skill's internal fan-out example now
+  leads with the preferred `define_subagent → invoke_subagent` form and **requires `--yolo`**
+  — on 1.1.3+ the subagent tools are soft-denied headless without it (the old "spawning needs
+  no `--yolo`" note was 1.0.x behavior). Re-verified live on 1.1.5 (two parallel subagents,
+  each with an auditable `transcript.jsonl` via `agy-trace`).
 
 ## 0.18.3
 - **`doctor` fix — recognize tier models across `agy models` format changes.** agy 1.1.5

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ skills/antigravity/SKILL.md   WHEN + HOW Claude collaborates with agy
 agents/           antigravity-delegate subagent (file work runs on Gemini, not Claude)
 commands/         slash commands (delegate, review, research, cloud-run-debug, setup, status, result, cancel)
 hooks/            SessionStart: agy health check + auto-inject the cost-aware policy
+bin/              PATH shims (bare names): agy-delegate · agy-job · agy-cost-compare · agy-doctor · cloud-debug · agy-trace · measure-session
 scripts/          agy-delegate · agy-job · agy-cost-compare · cloud-debug · agy-trace · measure-session · doctor
 docs/             AB-RESULTS (measured A/B) · POC-PLAYBOOK · TROUBLESHOOTING · DEMO-KIT
 prices.json       Vertex rate config (verify before quoting)

--- a/bin/measure-session
+++ b/bin/measure-session
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# bin/ entrypoint on the Bash-tool PATH (Claude Code adds a plugin's bin/ to PATH).
+# $CLAUDE_PLUGIN_ROOT is NOT exported to model-run Bash (issue #11), so commands and
+# skills invoke this bare name; it forwards to the implementation in ../scripts/measure-session.py.
+exec "$(cd "$(dirname "$0")/.." && pwd)/scripts/measure-session.py" "$@"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -142,7 +142,7 @@ done
 
 # 4b2. bin/ entrypoints executable (added to the Bash-tool PATH; commands/skills call
 #      these bare names — $CLAUDE_PLUGIN_ROOT is not exported to model-run Bash, issue #11)
-for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug agy-trace; do
+for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug agy-trace measure-session; do
   if [ -x "$ROOT/bin/$b" ]; then ok "bin/$b executable"; else
     bad "bin/$b not executable"; info "fix: chmod +x \"$ROOT/bin/$b\""
   fi

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -266,24 +266,29 @@ ONE delegation and let agy fan out internally — the coordination tokens land o
 cheap side, and you ingest a single digest.
 
 ```bash
-# Any version (fallback form). On agy >= 1.0.16, swap the instruction to:
-# "define_subagent a named specialist per unit, then invoke each by its TypeName".
-agy-delegate --dir . --digest --timeout 10m \
-  "Decompose <task> into up to 3 units. For each unit, invoke a background subagent
-   with TypeName \"self\" and a specialist Role (e.g. 'Test Writer'), each following
-   AGENTS.md. Wait for all of them, then report per-unit results, each subagent's
-   conversationId, and end with a DIGEST line."
+# Preferred form (agy >= 1.0.16). --yolo is required so the subagent tools aren't
+# soft-denied headless (see below). Verified live on agy 1.1.5.
+agy-delegate --dir . --yolo --digest --timeout 10m \
+  "ACTUALLY use your define_subagent and invoke_subagent tools (do NOT simulate).
+   Decompose <task> into up to 3 units. For each unit: define_subagent a named specialist
+   (name + system_prompt for its role, following this repo's conventions / AGENTS.md if
+   present), then invoke_subagent it by TypeName with the unit's work. Wait for ALL, then
+   report per-unit results, EACH subagent's conversationId, and end with a DIGEST line."
+# Any-version fallback: replace define/invoke with TypeName "self" + a specialist Role.
 ```
 
-Verified behaviors (1.0.12 → 1.0.16):
-- **Spawning needs no `--yolo`** — subagent invocation isn't permission-gated; file
-  writes / web tools *inside* the subagents' work still need it.
+Verified behaviors (1.0.12 → 1.1.5):
+- **Pass `--yolo`.** On 1.1.3+ the subagent tools need permission that headless mode
+  can't prompt for, so without `--yolo` the spawn is soft-denied (wrapper exit 15).
+  (On 1.0.x spawning was ungated, but `--yolo` is the durable choice; writes/web tools
+  *inside* the subagents' work always need it.)
 - Each spawn's tool result includes a `logAbsoluteUri` → a **readable step-by-step
   `transcript.jsonl`** under `~/.gemini/antigravity-cli/brain/<conversationId>/` —
   *better* trajectory visibility than a plain delegation. Location unchanged across
-  1.0.12→1.0.16, for both `define_subagent` and `self` spawns. Have the parent report
+  1.0.12→1.1.5, for both `define_subagent` and `self` spawns. Have the parent report
   each `conversationId`, then audit with `agy-trace <id>` (`agy-trace --list` finds
-  recent ones).
+  recent ones). Note: the parent may also create a coordination thread of its own, so
+  `--list` can show one more conversation than the units you asked for.
 - Spawns are real and observable (new conversation threads appear) — but still run the
   verification gates on the merged result; more autonomy = more surface for error.
 

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.18.3
+version: 0.18.4
 ---
 
 # Antigravity for Claude Code — hybrid SDLC

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -386,7 +386,7 @@ else echo "FAIL: delegate agent missing proactive-with-judgment description"; FA
 
 echo "== bin/ entrypoints (issue #11: \$CLAUDE_PLUGIN_ROOT not on model-run Bash) =="
 BIN="$ROOT/bin"
-for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug agy-trace; do
+for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug agy-trace measure-session; do
   if [ -x "$BIN/$b" ]; then echo "ok: bin/$b executable"; PASS=$((PASS+1));
   else echo "FAIL: bin/$b missing or not executable"; FAIL=$((FAIL+1)); fi
 done
@@ -398,6 +398,9 @@ case "$out" in *doctor*) echo "ok: bin/agy-doctor forwards to doctor.sh"; PASS=$
   *) echo "FAIL: bin/agy-doctor did not forward (got: '$out')"; FAIL=$((FAIL+1));; esac
 out=$(env -u CLAUDE_PLUGIN_ROOT "$BIN/cloud-debug" --service svc --print-command 2>/dev/null); rc=$?
 check "bin/cloud-debug forwards to cloud-debug.sh (no CLAUDE_PLUGIN_ROOT)" 0 "$rc" "logging read" "$out"
+out=$(env -u CLAUDE_PLUGIN_ROOT "$BIN/measure-session" 2>&1 | head -1)
+case "$out" in *measure-session*) echo "ok: bin/measure-session forwards to the .py"; PASS=$((PASS+1));;
+  *) echo "FAIL: bin/measure-session did not forward (got: '$out')"; FAIL=$((FAIL+1));; esac
 
 echo "== doctor.sh tier-model check (agy 1.1.5 slug format) =="
 # The stub's `agy models` emits slugs (gemini-3.5-flash); doctor's default tier models are
@@ -541,7 +544,7 @@ for s in ("hooks/check-agy.sh", "hooks/inject-policy.sh", "hooks/validate-delega
 
 # bin/ entrypoints exist + executable (issue #11: $CLAUDE_PLUGIN_ROOT isn't exported
 # to model-run Bash, so commands/skill must call these bare names on the PATH)
-for b in ("agy-delegate", "agy-job", "agy-cost-compare", "agy-doctor", "cloud-debug", "agy-trace"):
+for b in ("agy-delegate", "agy-job", "agy-cost-compare", "agy-doctor", "cloud-debug", "agy-trace", "measure-session"):
     need(os.access(p("bin", b), os.X_OK), "bin entrypoint missing/not executable: bin/" + b)
 
 # regression guard: commands & skill must NOT invoke $CLAUDE_PLUGIN_ROOT/scripts/* — that


### PR DESCRIPTION
`measure-session.py` was the only script without a `bin/` entrypoint, so on a marketplace install it could only be reached via the `scripts/` path — which doesn't resolve from a user's own repo. (Surfaced while reviewing the hands-on guide: `scripts/measure-session.py <session-id>` fails for a participant working in their own repo.)

- Added `bin/measure-session` (forwards to `scripts/measure-session.py`, same pattern as the other shims) → `measure-session <session-id>` now works on the Bash-tool PATH.
- `doctor`'s bin check + the contract test + a bin-forward test cover it.

**125 tests pass** · shellcheck clean · `claude plugin validate` passes.