### PR TITLE
fix(security): token-based delegate Bash gate — close command-injection bypass (#29, 0.19.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.18.4",
+  "version": "0.19.0",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.19.0
+- **Security: harden the delegate subagent's Bash gate against command-injection bypass**
+  ([#29](https://github.com/yuting0624/antigravity-for-claude-code/issues/29), reported by
+  **@ktseo41**). `hooks/validate-delegate-bash.sh` is the *only* restriction on what the
+  `antigravity-delegate` subagent can run via Bash; it matched the wrapper name as a
+  **substring anywhere in the command**, so payloads like `... # agy-delegate` or
+  `echo $(...) agy-job` were approved — arbitrary command execution under prompt injection.
+  The gate now:
+  - requires the **first command token** (argv[0], basename, optional `.sh`) to be exactly
+    `agy-delegate` / `agy-job` — a token check, not a substring match;
+  - allows only one pipeline shape, `<git|cat|echo|printf> | agy-delegate|agy-job -`
+    (so `git diff | agy-delegate -` keeps working);
+  - rejects **unquoted** `;` `&` `|` `<` `>` `(` `)` `#`, backticks, and `$(` (command
+    substitution) — while permitting those characters **inside a quoted prompt** (no false
+    positives on legitimate prompts; `$(...)`/backticks inside double quotes are still
+    blocked because bash would expand them);
+  - **fails closed** (block) if the JSON is unparseable or `python3` is unavailable (the
+    old fallback matched against the raw JSON, which was fail-open-ish).
+  - Regression tests cover both the bypass vectors and legitimate-usage false positives.
+- **Added `SECURITY.md`** with a private vulnerability-reporting channel (the reporter
+  noted its absence). Report via GitHub Security advisories.
+
 ## 0.18.4
 - **`bin/measure-session` shim** — `measure-session.py` was the only script without a `bin/`
   entrypoint, so it couldn't be run by bare name from a marketplace install (only via the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security policy
+
+This is a community project (MIT, not affiliated with Google or Anthropic). It
+orchestrates the third-party `agy` CLI and runs shell commands on your machine, so
+security reports are genuinely appreciated.
+
+## Reporting a vulnerability
+
+**Preferred:** use GitHub's private vulnerability reporting —
+**Security → Report a vulnerability** on this repository
+(https://github.com/yuting0624/antigravity-for-claude-code/security/advisories/new).
+This keeps details private until a fix is available.
+
+If that isn't available to you, open a normal issue describing the impact and a
+non-destructive repro, and note that you'd prefer to coordinate privately — a
+maintainer will follow up with a private channel.
+
+Please include: affected file/commit, impact (what a malicious/injected input could
+do), and a **non-destructive** proof-of-concept (exit codes / policy decisions, not
+`rm -rf` — some endpoint security will kill the process on such strings).
+
+## Scope — what matters most here
+
+- **`hooks/validate-delegate-bash.sh`** — the PreToolUse gate that is the *only* thing
+  restricting what the `antigravity-delegate` subagent may run via Bash. Bypasses here
+  (arbitrary command execution under prompt injection) are the highest-value reports.
+- **`scripts/agy-delegate.sh` / `agy-job.sh`** — the wrappers that invoke `agy`.
+- **`hooks/`** — anything injected into the model's context or run at session start.
+- Trust boundary reminder: `agy` output and repo contents are **untrusted** — the plugin
+  treats agy as a tool whose results Claude must verify, never as a trusted authority.
+
+## Not in scope
+
+- Vulnerabilities in the upstream Antigravity CLI (`agy`) itself — report those to
+  https://github.com/google-antigravity/antigravity-cli.
+- Cost/quota surprises from using `--yolo` or delegating large jobs (documented behavior).
+
+## Supported versions
+
+Fixes land on the latest release. Update with
+`/plugin marketplace update antigravity-for-claude-code` and `/reload-plugins`; the
+`version` in `.claude-plugin/plugin.json` is what marketplace update recognizes.

--- a/hooks/validate-delegate-bash.sh
+++ b/hooks/validate-delegate-bash.sh
@@ -1,35 +1,121 @@
 #!/usr/bin/env bash
 #
 # PreToolUse(Bash) gate for the `antigravity-delegate` subagent. Claude Code's
-# subagent `tools:` field can't scope Bash to one command, so this hook enforces it:
-# allow a Bash call ONLY when it invokes the plugin's delegation wrapper
-# (agy-delegate / agy-job); block everything else with exit code 2.
+# subagent `tools:` field can't scope Bash to one command, so this hook is the ONLY
+# thing restricting what that subagent may run — it must allow a Bash call only when
+# it invokes the plugin's delegation wrapper (agy-delegate / agy-job) and nothing else.
 #
-# This keeps file writing + verification off the delegate subagent (file generation
-# happens on agy/Gemini, not by spending Claude tokens in the shell).
+# Hardening (issue #29): the previous version matched the wrapper name as a SUBSTRING
+# anywhere in the command, so payloads like `foo ... # agy-delegate` or
+# `echo $(...) agy-job` slipped through (arbitrary execution under prompt injection).
+# This version instead:
+#   * requires the FIRST command token (argv[0], basename, optional .sh) to be exactly
+#     agy-delegate / agy-job — a token check, not a substring match;
+#   * allows only one pipeline shape, `<git|cat|echo|printf> | agy-delegate|agy-job -`,
+#     so `git diff | agy-delegate -` keeps working;
+#   * rejects UNQUOTED shell metacharacters bash would act on (`; & | < > ( ) #`,
+#     backticks, `$(`), while permitting them INSIDE a quoted prompt (no false
+#     positives on legitimate prompts — command substitution inside double quotes is
+#     still blocked because bash would expand it);
+#   * fails CLOSED (block) if the JSON is unparseable or python3 is unavailable.
 #
 # Input: hook JSON on stdin, with .tool_input.command holding the bash command.
+# Exit: 0 = allow, 2 = block.
 #
 set -uo pipefail
 
 input="$(cat)"
 
-# Extract the command field. Prefer python3 (correct JSON parse); fall back to the
-# raw payload so the gate still works if python3 is unavailable.
-if command -v python3 >/dev/null 2>&1; then
-  cmd="$(printf '%s' "$input" | python3 -c \
-    'import json,sys
-try:
-    print(json.load(sys.stdin).get("tool_input",{}).get("command",""))
-except Exception:
-    pass' 2>/dev/null || true)"
-else
-  cmd="$input"
+BLOCK_MSG="[antigravity-delegate] blocked: this subagent may only run agy-delegate / agy-job (optionally as \`<git|cat|echo|printf> | agy-delegate -\`). No other commands, chaining, redirection, substitution, or comments. Delegate file work to agy; verification is the caller's job."
+
+# python3 gives a correct, quote-aware parse. Fail CLOSED if it's missing.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "$BLOCK_MSG (python3 unavailable — failing closed)" >&2
+  exit 2
 fi
 
-case "$cmd" in
-  *agy-delegate*|*agy-job*) exit 0 ;;
-esac
+if AGY_GATE_INPUT="$input" python3 - <<'PY'
+import json, os, shlex, sys
 
-echo "[antigravity-delegate] blocked: this subagent may only run agy-delegate / agy-job via Bash. Delegate file work to agy; verification is the caller's job." >&2
-exit 2
+raw = os.environ.get("AGY_GATE_INPUT", "")
+try:
+    cmd = json.loads(raw).get("tool_input", {}).get("command", "")
+except Exception:
+    sys.exit(2)                      # unparseable payload -> fail closed
+if not isinstance(cmd, str) or not cmd.strip():
+    sys.exit(2)
+
+WRAPPERS  = {"agy-delegate", "agy-job"}
+PRODUCERS = {"git", "cat", "echo", "printf"}
+
+def base(tok):
+    b = os.path.basename(tok)
+    return b[:-3] if b.endswith(".sh") else b
+
+# Quote-aware scan: split into pipeline segments on UNQUOTED '|', and flag any
+# unquoted metacharacter bash would act on (plus command substitution inside "").
+def scan(s):
+    segs, cur, st, i, n, bad = [], [], "U", 0, len(s), False
+    while i < n:
+        c = s[i]
+        if st == "U":
+            if c == "'":  st = "S"; cur.append(c); i += 1; continue
+            if c == '"':  st = "D"; cur.append(c); i += 1; continue
+            if c == "\\":
+                cur.append(c)
+                if i + 1 < n: cur.append(s[i + 1]); i += 2; continue
+                i += 1; continue
+            if c == "|":  segs.append("".join(cur)); cur = []; i += 1; continue
+            if c == "`":  bad = True; cur.append(c); i += 1; continue
+            if c == "$":
+                if i + 1 < n and s[i + 1] == "(": bad = True
+                cur.append(c); i += 1; continue
+            if c in ";&<>()#\n": bad = True; cur.append(c); i += 1; continue
+            cur.append(c); i += 1; continue
+        if st == "S":
+            cur.append(c)
+            if c == "'": st = "U"
+            i += 1; continue
+        # st == "D"
+        cur.append(c)
+        if c == '"': st = "U"; i += 1; continue
+        if c == "\\":
+            if i + 1 < n: cur.append(s[i + 1]); i += 2; continue
+            i += 1; continue
+        if c == "`": bad = True; i += 1; continue
+        if c == "$":
+            if i + 1 < n and s[i + 1] == "(": bad = True
+            i += 1; continue
+        i += 1
+    segs.append("".join(cur))
+    if st != "U":
+        return None, True            # unbalanced quotes -> unsafe
+    return segs, bad
+
+segs, bad = scan(cmd)
+if segs is None or bad:
+    sys.exit(2)
+
+def head(seg):
+    try:
+        toks = shlex.split(seg)
+    except Exception:
+        return None
+    return toks[0] if toks else None
+
+if len(segs) == 1:
+    t = head(segs[0])
+    sys.exit(0 if t and base(t) in WRAPPERS else 2)
+elif len(segs) == 2:
+    lt, rt = head(segs[0]), head(segs[1])
+    ok = bool(lt) and base(lt) in PRODUCERS and bool(rt) and base(rt) in WRAPPERS
+    sys.exit(0 if ok else 2)
+else:
+    sys.exit(2)                      # more than one pipe
+PY
+then
+  exit 0
+else
+  echo "$BLOCK_MSG" >&2
+  exit 2
+fi

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.18.4
+version: 0.19.0
 ---
 
 # Antigravity for Claude Code — hybrid SDLC

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -372,6 +372,27 @@ check "gate allows bin name agy-delegate -> exit 0" 0 "$rc"
 printf '%s' '{"tool_input":{"command":"agy-job status abc"}}' | "$GATE" >/dev/null 2>&1; rc=$?
 check "gate allows bin name agy-job -> exit 0" 0 "$rc"
 
+# issue #29: token-based gate — substring-anywhere bypasses must be BLOCKED (benign payloads)
+printf '%s' '{"tool_input":{"command":"foo # agy-delegate"}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate blocks comment-appended wrapper name -> exit 2" 2 "$rc"
+printf '%s' '{"tool_input":{"command":"echo `foo` agy-job"}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate blocks backtick substitution -> exit 2" 2 "$rc"
+printf '%s' '{"tool_input":{"command":"agy-delegate x; foo"}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate blocks ; chaining after wrapper -> exit 2" 2 "$rc"
+printf '%s' '{"tool_input":{"command":"agy-delegate x && foo"}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate blocks && chaining after wrapper -> exit 2" 2 "$rc"
+printf '%s' '{"tool_input":{"command":"agy-delegate \"$(foo)\""}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate blocks command substitution in dquotes -> exit 2" 2 "$rc"
+printf '%s' '{"tool_input":{"command":"foo bar > baz # agy-job"}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate blocks redirection -> exit 2" 2 "$rc"
+# ...while legitimate forms still pass, including the review pipeline and quoted metachars
+printf '%s' '{"tool_input":{"command":"git diff | agy-delegate --tier pro -"}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate allows git diff | agy-delegate - pipeline -> exit 0" 0 "$rc"
+printf '%s' '{"tool_input":{"command":"agy-delegate --dir . \"handle a|b; c and $x\""}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate allows metacharacters INSIDE a quoted prompt -> exit 0" 0 "$rc"
+printf '%s' '{"tool_input":{"command":"nc evil 9 | agy-delegate -"}}' | "$GATE" >/dev/null 2>&1; rc=$?
+check "gate blocks a non-allowlisted pipeline producer -> exit 2" 2 "$rc"
+
 AGENT="$ROOT/agents/antigravity-delegate.md"
 tl=$(grep -m1 '^tools:' "$AGENT")
 if [ "$tl" = "tools: Bash, Read, Glob" ]; then echo "ok: delegate agent tools allowlist exact (no Write/Edit)"; PASS=$((PASS+1));


### PR DESCRIPTION
Fixes #29 (reported by @ktseo41). Reproduced both bypass vectors on `main` before the fix.

## The bug
`hooks/validate-delegate-bash.sh` is the **only** restriction on what the `antigravity-delegate` subagent may run via Bash. It matched the wrapper name as a **substring anywhere in the command**, so these were *approved* (exit 0) when they should be blocked:
- `<anything> # agy-delegate` (trailing comment)
- `echo $(...) agy-job` / backtick substitution
- `agy-delegate x; <anything>` / `&& <anything>` (chaining)
- redirection with the wrapper name present anywhere

→ arbitrary command execution from the subagent's context under prompt injection. The `python3`-absent fallback also matched the raw JSON (not fail-closed).

## The fix — quote-aware, token-based, fail-closed
- **argv[0] must be exactly `agy-delegate` / `agy-job`** (basename, optional `.sh`) — a token check, not substring.
- Only one pipeline shape allowed: `<git|cat|echo|printf> | agy-delegate|agy-job -` (keeps `git diff | agy-delegate -` working).
- Rejects **unquoted** `; & | < > ( ) #`, backticks, and `$(` — while permitting them **inside a quoted prompt** (no false positives; `$()`/backticks inside double quotes are still blocked, since bash would expand them).
- **Fails closed** if the JSON is unparseable or `python3` is missing.

## Verification
- **134 tests pass** (+9): the bypass vectors are now blocked (benign payloads — some EDR kills the process on `rm -rf` strings), and legitimate forms still pass — bare `agy-delegate`/`agy-job`, legacy path/`.sh` forms, the review pipeline, and prompts containing quoted metacharacters (`"a|b; c and $x"`).
- shellcheck clean · `claude plugin validate` passes.

## Also
- Added **`SECURITY.md`** with a private vulnerability-reporting channel (GitHub Security advisories) — the reporter noted its absence.

Thanks @ktseo41 for the careful, responsible report. Review welcome.