### PR TITLE
feat: /antigravity:media — delegate audio/video/image understanding to Gemini (0.20.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.20.0
+- **New: multimodal delegation — `/antigravity:media` (`agy-media`).** Claude Code can't
+  hear audio or watch video, and doing it locally means an ffmpeg + speech-model stack.
+  Gemini is natively multimodal, so this delegates the perception to agy — **no local
+  transcription stack required**. Verified end to end on agy 1.1.7 (audio transcribed;
+  video analyzed with per-scene visuals + OCR + speech).
+  - **Cost discipline built in (the differentiator):** agy writes the **full timestamped
+    transcript to a file** and returns only a compact **digest** (summary · timestamped
+    outline · key points · quotes with `[mm:ss]` · action items · visuals · uncertainty
+    notes). A 1-hour recording is ~10k words — exactly the `cache_read` blow-up the plugin
+    exists to avoid, so it never lands in the conductor's context; Claude reads *slices* of
+    the transcript on demand to verify.
+  - **Format pre-flight:** agy's media handling is narrower than the Gemini API. Verified
+    working: `wav mp3 flac ogg opus | mp4 mov webm | png jpg webp`. **`.m4a` / `.aiff`
+    fail** (inconsistently — "invalid argument" or a hang) despite Gemini itself accepting
+    them — an agy-side gap. Rather than surfacing that cryptic failure, the engine checks
+    the extension first, exits `5` with the exact conversion one-liner, and `--convert`
+    does it for you (macOS `afconvert`, else `ffmpeg`).
+  - **Verification framing:** the digest must flag inaudible passages and uncertain
+    names/numbers; the command tells Claude to treat those as unverified and check the
+    transcript slice before relying on them. Warns if agy returns a digest without
+    actually writing the transcript file.
+  - Long media: default `--timeout 15m`, size heads-up over 25 MB, and guidance to split
+    (~30-min chunks) if it still times out.
+
 ## 0.19.0
 - **Security: harden the delegate subagent's Bash gate against command-injection bypass**
   ([#29](https://github.com/yuting0624/antigravity-for-claude-code/issues/29), reported by

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ you → Claude Code (conduct: design / verify / review)
 
 - **Routes work across the SDLC** — Claude keeps the judgement calls; Antigravity handles scaffolding, **test generation**, **first-pass review**, and **migrations** under a shared `AGENTS.md`.
 - **Adds tools Claude lacks natively** — live **Google/web search**, **Vertex AI Search** over your internal data, deep research, Cloud Logging. Claude reviews and re-checks the results.
+- **Hears audio, watches video** — `/antigravity:media` delegates the perception to Gemini (natively multimodal, **no local ffmpeg/Whisper stack**): you get a **timestamped digest** while the full transcript is written to a file, so a 1-hour recording never lands in Claude's context.
 - **Cross-model verification** — an independent, different-model opinion on your code.
 - **Background jobs** — fire a long delegation, keep working, collect later.
 - **Internal fan-out** — one delegation, and agy spawns its own subagents on the cheap side (dynamic `define_subagent` on agy ≥ 1.0.16; `TypeName "self"` + Role on any version); each leaves a **readable trajectory** you audit with `agy-trace`.
@@ -91,6 +92,7 @@ In Claude Code:
 | `/antigravity:delegate [--tier flash\|pro] <task>` | delegate a subtask to agy under cost discipline, then verify |
 | `/antigravity:review [--adversarial]` | independent cross-model review of the current diff; Claude reconciles |
 | `/antigravity:research <topic>` | Claude-orchestrated deep research — agy does grounded web legwork, Claude verifies citations across ≥2 sources |
+| `/antigravity:media <file> [focus] [--convert]` | understand audio / video / images — agy transcribes + analyzes, returns a **timestamped digest**; full transcript goes to a file, not your context |
 | `/antigravity:cloud-run-debug [--service <s>] [--region <r>] [--project <id>] [--since 1h] [--apply]` | diagnose a failing Cloud Run service — agy digests the error logs, Claude infers the root cause + fix; read-only by default (`--apply` writes to a branch) |
 | `/antigravity:status [id]` · `:result <id>` · `:cancel <id>` | manage background delegation jobs |
 
@@ -184,10 +186,10 @@ Delegation doesn't save money by itself — these do (also in the skill):
 .claude-plugin/   plugin (+ userConfig: default_tier, timeout, coding_policy) + marketplace manifests
 skills/antigravity/SKILL.md   WHEN + HOW Claude collaborates with agy
 agents/           antigravity-delegate subagent (file work runs on Gemini, not Claude)
-commands/         slash commands (delegate, review, research, cloud-run-debug, setup, status, result, cancel)
+commands/         slash commands (delegate, review, research, media, cloud-run-debug, setup, status, result, cancel)
 hooks/            SessionStart: agy health check + auto-inject the cost-aware policy
-bin/              PATH shims (bare names): agy-delegate · agy-job · agy-cost-compare · agy-doctor · cloud-debug · agy-trace · measure-session
-scripts/          agy-delegate · agy-job · agy-cost-compare · cloud-debug · agy-trace · measure-session · doctor
+bin/              PATH shims (bare names): agy-delegate · agy-job · agy-cost-compare · agy-doctor · cloud-debug · agy-trace · agy-media · measure-session
+scripts/          agy-delegate · agy-job · agy-cost-compare · cloud-debug · agy-trace · agy-media · measure-session · doctor
 docs/             AB-RESULTS (measured A/B) · POC-PLAYBOOK · TROUBLESHOOTING · DEMO-KIT
 prices.json       Vertex rate config (verify before quoting)
 ```

--- a/bin/agy-media
+++ b/bin/agy-media
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# bin/ entrypoint on the Bash-tool PATH (Claude Code adds a plugin's bin/ to PATH).
+# $CLAUDE_PLUGIN_ROOT is NOT exported to model-run Bash (issue #11), so commands and
+# skills invoke this bare name; it forwards to the implementation in ../scripts/agy-media.sh.
+exec "$(cd "$(dirname "$0")/.." && pwd)/scripts/agy-media.sh" "$@"

--- a/commands/media.md
+++ b/commands/media.md
@@ -1,0 +1,51 @@
+---
+description: Understand an audio / video / image file — Antigravity (agy/Gemini) transcribes and analyzes it, returning a timestamped digest while the full transcript goes to a file.
+argument-hint: "<file> [what to focus on] [--convert] [--tier pro|flash] [--timeout 20m]"
+---
+
+Claude Code can't hear audio or watch video, and doing it locally means an ffmpeg +
+speech-model stack. Gemini is natively multimodal — so **delegate the perception** to agy
+and keep the judgment here.
+
+Input: $ARGUMENTS
+
+Do this:
+
+1. **Resolve the file.** First arg is the path; anything else (that isn't a flag) is the
+   focus/question. If no file was given, ask which one (AskUserQuestion) — don't guess.
+
+2. **Delegate** (the engine handles format pre-flight, the digest contract, and writes the
+   full transcript to a file):
+   ```
+   agy-media <file> [focus] [--convert] [--tier pro|flash] [--timeout 20m] [--out <path>]
+   ```
+   - Default tier is `pro` (better timestamps/diarization); `--tier flash` is fine for
+     short/simple clips.
+   - Long media needs headroom: raise `--timeout` (e.g. `20m`) for anything over a few
+     minutes. If it still times out (exit 12), split the file into ~30-min chunks and run
+     them separately.
+   - **Exit 5 = unsupported format.** agy mishandles `.m4a` / `.aiff` (common for voice
+     memos) even though Gemini accepts them. The engine prints the exact conversion
+     command — re-run with `--convert` to have it converted automatically (macOS
+     `afconvert`, else `ffmpeg`).
+
+3. **Ingest ONLY the digest** it prints (summary · timestamped outline · key points ·
+   quotes · action items · visuals · uncertainty notes). **Do not read the whole
+   transcript file into context** — a 1-hour recording is ~10k words and re-reading it
+   every turn is exactly the cost blow-up this plugin exists to avoid. The transcript file
+   is there so you can grep/read *slices* on demand.
+
+4. **Verify before you rely on it** (transcription is not ground truth):
+   - Check the transcript file actually exists (the engine warns if it doesn't).
+   - The digest flags unclear audio and uncertain names/numbers — **treat those as
+     unverified**. For any load-bearing figure, name, or quote, read that timestamp's
+     slice from the transcript file (e.g. `grep -n "\[12:3" <transcript>`) rather than
+     trusting the summary.
+   - Say plainly which claims you confirmed and which are still the model's guess.
+
+5. **Report**: the digest's substance (not a re-paste), where the transcript lives, and
+   what you verified. If the user asked a specific question, answer it with `[mm:ss]`
+   citations so they can jump to the source.
+
+Good uses: meeting/interview notes, a screencast or demo video, a voice memo, a
+conference talk, a UI walkthrough, an architecture diagram or screenshot.

--- a/scripts/agy-media.sh
+++ b/scripts/agy-media.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# agy-media.sh — hand an audio / video / image file to Antigravity (`agy` / Gemini)
+# and get back a TIMESTAMPED DIGEST, with the full transcript written to a file.
+# Part of the "Antigravity for Claude Code" plugin.
+#
+# Why this exists: Claude Code can't hear audio or watch video, and adding that
+# locally means ffmpeg + a speech model. Gemini is natively multimodal, so this
+# delegates the perception work to agy — no local transcription stack needed.
+#
+# Cost discipline (the point): a 1-hour meeting is ~10k words. Pasting that into
+# the conductor's context is exactly the `cache_read` blow-up the plugin exists to
+# avoid. So agy writes the FULL transcript to a file and returns only a compact,
+# timestamped digest; Claude ingests the digest and reads slices of the transcript
+# only when it needs to verify something.
+#
+# Format pre-flight: agy's file→media handling is narrower than the Gemini API.
+# Verified on agy 1.1.7: wav / mp3 / flac / ogg / mp4 / png work; m4a and aiff fail
+# (inconsistently — "invalid argument" or a hang). Rather than let users hit that,
+# this script checks the extension first and prints the exact conversion one-liner
+# (or converts for you with --convert, using macOS afconvert or ffmpeg).
+#
+# Usage:
+#   agy-media.sh <file> [focus/question] [options]
+#
+# Options:
+#   -o, --out <path>      Where agy writes the full transcript
+#                         (default: <file-dir>/<file-stem>.transcript.md)
+#       --convert         Auto-convert an unsupported audio format to wav first
+#                         (uses afconvert on macOS, else ffmpeg; writes next to the source)
+#   -t, --tier <tier>     Delegation tier (default: pro — better at timestamps/diarization)
+#       --timeout <dur>   agy print-timeout (default: 15m; long media needs headroom)
+#       --print-command   Show the resolved agy-delegate call and exit (dry run)
+#   -h, --help            Show this help
+#
+# Exit codes: 0 ok | 1 usage | 4 file not found | 5 unsupported format (convert first)
+#             | otherwise the agy-delegate exit code (2 failed · 3 empty · 10 quota ·
+#               11 auth · 12 timeout · 13 agy missing · 14 model · 15 permission)
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DELEGATE="${AGY_DELEGATE:-$HERE/agy-delegate.sh}"
+
+FILE=""; FOCUS=""; OUT=""; TIER="pro"; TIMEOUT="15m"; CONVERT=0; PRINT_CMD=0
+
+die()   { echo "agy-media: $*" >&2; exit 1; }
+need()  { [ "$1" -ge 2 ] || die "option '$2' needs a value"; }
+usage() { sed -n '/^# Usage:/,/^# Exit codes:/p' "$0" | sed 's/^# \{0,1\}//'; exit 0; }
+
+# Formats verified to work through agy headless (1.1.7).
+is_supported() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    wav|mp3|flac|ogg|opus|mp4|mov|webm|png|jpg|jpeg|gif|webp) return 0 ;;
+  esac
+  return 1
+}
+# Audio formats agy mishandles today but that convert cleanly to wav.
+is_convertible() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    m4a|aiff|aif|aac|caf|wma|amr) return 0 ;;
+  esac
+  return 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o|--out)        need "$#" "$1"; OUT="$2"; shift 2 ;;
+    --convert)       CONVERT=1; shift ;;
+    -t|--tier)       need "$#" "$1"; TIER="$2"; shift 2 ;;
+    --timeout)       need "$#" "$1"; TIMEOUT="$2"; shift 2 ;;
+    --print-command) PRINT_CMD=1; shift ;;
+    -h|--help)       usage ;;
+    -*)              die "unknown option '$1'" ;;
+    *)               if [ -z "$FILE" ]; then FILE="$1"; else
+                       FOCUS="${FOCUS:+$FOCUS }$1"; fi; shift ;;
+  esac
+done
+
+[ -n "$FILE" ] || die "no media file given (usage: agy-media.sh <file> [focus])"
+[ -f "$FILE" ] || { echo "agy-media: file not found: $FILE" >&2; exit 4; }
+
+# Absolute path: agy resolves the workspace, not our cwd.
+ABS="$(cd "$(dirname "$FILE")" && pwd)/$(basename "$FILE")"
+DIR="$(dirname "$ABS")"
+STEM="$(basename "$ABS")"; STEM="${STEM%.*}"
+EXT="${ABS##*.}"
+
+# --- format pre-flight -------------------------------------------------------
+if ! is_supported "$EXT"; then
+  if is_convertible "$EXT"; then
+    CONVERTED="$DIR/$STEM.wav"
+    if [ "$CONVERT" -eq 1 ]; then
+      echo "agy-media: converting .$EXT -> wav (agy mishandles .$EXT)…" >&2
+      if command -v afconvert >/dev/null 2>&1; then
+        afconvert -f WAVE -d LEI16@16000 -c 1 "$ABS" "$CONVERTED" >/dev/null 2>&1 \
+          || die "afconvert failed converting '$ABS'"
+      elif command -v ffmpeg >/dev/null 2>&1; then
+        ffmpeg -loglevel error -i "$ABS" -ar 16000 -ac 1 "$CONVERTED" -y >/dev/null 2>&1 \
+          || die "ffmpeg failed converting '$ABS'"
+      else
+        echo "agy-media: no converter found (need afconvert on macOS, or ffmpeg)" >&2
+        exit 5
+      fi
+      ABS="$CONVERTED"; EXT="wav"
+      echo "agy-media: converted -> $ABS" >&2
+    else
+      echo "agy-media: '.$EXT' is not reliably supported by agy (verified on 1.1.7: it fails with 'invalid argument' or hangs) — even though Gemini itself accepts it." >&2
+      echo "agy-media: re-run with --convert, or convert once yourself:" >&2
+      if command -v afconvert >/dev/null 2>&1; then
+        echo "  afconvert -f WAVE -d LEI16@16000 -c 1 \"$ABS\" \"$CONVERTED\"" >&2
+      else
+        echo "  ffmpeg -i \"$ABS\" -ar 16000 -ac 1 \"$CONVERTED\"" >&2
+      fi
+      echo "agy-media: supported today: wav mp3 flac ogg opus | mp4 mov webm | png jpg webp" >&2
+      exit 5
+    fi
+  else
+    echo "agy-media: unrecognized media extension '.$EXT'." >&2
+    echo "agy-media: supported: wav mp3 flac ogg opus | mp4 mov webm | png jpg webp" >&2
+    exit 5
+  fi
+fi
+
+[ -n "$OUT" ] || OUT="$DIR/$STEM.transcript.md"
+case "$OUT" in /*) ;; *) OUT="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")" ;; esac
+
+# Size heads-up: long media is the usual cause of a timeout.
+BYTES="$(wc -c < "$ABS" 2>/dev/null | tr -d ' ')"
+if [ -n "$BYTES" ] && [ "$BYTES" -gt 26214400 ]; then
+  echo "agy-media: note: $((BYTES / 1048576)) MB input — long media can exceed the model's window and the print-timeout. If it times out, split the file (e.g. ~30 min chunks) and run them separately." >&2
+fi
+
+# --- build the delegation prompt --------------------------------------------
+# Contract: full transcript -> FILE; only a timestamped digest -> stdout (Claude).
+IS_VISUAL=0
+case "$EXT" in mp4|mov|webm|png|jpg|jpeg|gif|webp) IS_VISUAL=1 ;; esac
+VISUAL_LINE=""
+if [ "$IS_VISUAL" -eq 1 ]; then
+  VISUAL_LINE="
+- VISUALS: note what is on screen (scenes, slides, diagrams, UI, on-screen text/OCR) with timestamps; for a still image, describe it and transcribe any text."
+fi
+
+FOCUS_HINT=""
+[ -n "$FOCUS" ] && FOCUS_HINT=" Focus especially on: $FOCUS."
+
+PROMPT="Analyze the media file at $ABS.$FOCUS_HINT
+
+STEP 1 -- write the full record to a file:
+Write a complete, verbatim transcript to $OUT (create/overwrite it). Every line must start with a [mm:ss] timestamp (use [hh:mm:ss] past an hour). Attribute speakers as Speaker 1/2/... if more than one is audible. Do NOT put the full transcript in your reply.
+
+STEP 2 -- reply with ONLY a compact digest (no full transcript, no raw dump):
+- SUMMARY: 3-6 sentences on what this is and what matters.
+- OUTLINE: the timestamped chapters/sections, one line each, as [mm:ss] topic.
+- KEY POINTS: the load-bearing facts/decisions, each with its [mm:ss] source.
+- QUOTES: up to 5 short verbatim quotes worth citing, each with [mm:ss].
+- ACTION ITEMS / OPEN QUESTIONS: if any, each with [mm:ss] (say 'none' if none).$VISUAL_LINE
+- NOTE any audio that was unclear/inaudible, and any names/numbers you are unsure of, with their [mm:ss] -- do not silently guess.
+Finish with one line: DIGEST: <one-sentence takeaway>.
+
+Transcript file: $OUT"
+
+# --- delegate ----------------------------------------------------------------
+# --yolo: agy needs tool permission to read the media file and write the transcript.
+ARGS=(--tier "$TIER" --yolo --dir "$DIR" --timeout "$TIMEOUT")
+if [ "$PRINT_CMD" -eq 1 ]; then
+  { printf 'agy-delegate'; printf ' %q' "${ARGS[@]}" "$PROMPT"; printf '\n'; }
+  exit 0
+fi
+
+echo "agy-media: delegating $(basename "$ABS") to agy ($TIER, timeout $TIMEOUT); full transcript -> $OUT" >&2
+"$DELEGATE" "${ARGS[@]}" "$PROMPT"
+rc=$?
+
+if [ "$rc" -eq 0 ] && [ ! -f "$OUT" ]; then
+  echo "agy-media: WARNING — agy returned a digest but the transcript file was not created at $OUT. Verify before trusting the digest (agy may have skipped the write step)." >&2
+fi
+exit "$rc"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -127,7 +127,7 @@ else
 fi
 
 # 4. plugin scripts executable
-for s in agy-delegate.sh agy-cost-compare.sh cloud-debug.sh agy-trace.sh; do
+for s in agy-delegate.sh agy-cost-compare.sh cloud-debug.sh agy-trace.sh agy-media.sh; do
   if [ -x "$HERE/$s" ]; then ok "$s executable"; else
     bad "$s not executable"; info "fix: chmod +x \"$HERE/$s\""
   fi
@@ -142,7 +142,7 @@ done
 
 # 4b2. bin/ entrypoints executable (added to the Bash-tool PATH; commands/skills call
 #      these bare names — $CLAUDE_PLUGIN_ROOT is not exported to model-run Bash, issue #11)
-for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug agy-trace measure-session; do
+for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug agy-trace measure-session agy-media; do
   if [ -x "$ROOT/bin/$b" ]; then ok "bin/$b executable"; else
     bad "bin/$b not executable"; info "fix: chmod +x \"$ROOT/bin/$b\""
   fi

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.19.0
+version: 0.20.0
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -44,6 +44,7 @@ Route each phase to the right model. This is the core policy.
 | Cross-model verification (output + trajectory) | **both** | two model families ≠ same failure |
 | Maintenance / migration / modernization | **agy** executes, **Claude** directs | tedious, systematic |
 | Web / Vertex AI Search | **agy** → **Claude** re-checks | tools Claude lacks natively |
+| Audio / video understanding | **agy** transcribes + digests · **Claude** verifies | Gemini is natively multimodal; no local ffmpeg/speech stack |
 | Deep research (multi-source) | **agy** fans out search/fetch · **Claude** plans, verifies ≥2 sources, synthesizes | offload bulky pages to cheap Gemini; frontier model judges |
 
 Routing tier within agy: `flash` (default, bulk) · `flash-lo` (cheapest, trivial) ·
@@ -234,6 +235,15 @@ ROOT=agy-delegate
 
 # Web search → Claude re-checks
 "$ROOT" --tier pro --yolo "Use web search for <X>. Give URLs + dates."
+
+# Audio / video / image understanding (Claude can't hear or watch; Gemini can)
+# agy-media writes the full transcript to a FILE and returns a timestamped digest —
+# never ingest a whole transcript (a 1-hour recording is ~10k words of cache_read).
+agy-media ./meeting.wav "decisions and owners"     # digest -> you; transcript -> ./meeting.transcript.md
+agy-media ./demo.mp4 --timeout 20m                 # video: adds timestamped VISUALS/OCR
+agy-media ./memo.m4a --convert                     # agy mishandles m4a/aiff; converts to wav first
+# Verify before relying on it: the digest flags unclear audio + uncertain names/numbers —
+# grep that timestamp out of the transcript file rather than trusting the summary.
 
 # Vertex AI Search over internal data (discover engines, then query)
 "$ROOT" --tier pro --yolo "List Vertex AI Search engines (list_engines)."

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -407,7 +407,7 @@ else echo "FAIL: delegate agent missing proactive-with-judgment description"; FA
 
 echo "== bin/ entrypoints (issue #11: \$CLAUDE_PLUGIN_ROOT not on model-run Bash) =="
 BIN="$ROOT/bin"
-for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug agy-trace measure-session; do
+for b in agy-delegate agy-job agy-cost-compare agy-doctor cloud-debug agy-trace measure-session agy-media; do
   if [ -x "$BIN/$b" ]; then echo "ok: bin/$b executable"; PASS=$((PASS+1));
   else echo "FAIL: bin/$b missing or not executable"; FAIL=$((FAIL+1)); fi
 done
@@ -433,6 +433,30 @@ else echo "ok: doctor recognizes tier models across display-name/slug formats"; 
 if printf '%s' "$out" | grep -q "tier model present: Gemini 3.5 Flash (High)"; then
   echo "ok: doctor matches default flash tier in slug format"; PASS=$((PASS+1));
 else echo "FAIL: doctor did not confirm the default flash tier present"; FAIL=$((FAIL+1)); fi
+
+echo "== agy-media.sh (multimodal delegation) =="
+MEDIA="$ROOT/scripts/agy-media.sh"
+MDIR="$TMP/media"; mkdir -p "$MDIR"
+: > "$MDIR/clip.wav"; : > "$MDIR/memo.m4a"; : > "$MDIR/demo.mp4"; : > "$MDIR/notes.txt"
+# dry run resolves a delegation with --yolo (needed to read the file) and a transcript path
+out=$(AGY_DELEGATE=/nonexistent "$MEDIA" "$MDIR/clip.wav" --print-command 2>/dev/null); rc=$?
+check "media dry-run resolves a delegation" 0 "$rc" "agy-delegate" "$out"
+check "media passes --yolo (needed to read media)" 0 "$rc" "--yolo" "$out"
+check "media requests a timestamped transcript file" 0 "$rc" "clip.transcript.md" "$out"
+check "media enforces the digest contract" 0 "$rc" "ONLY a compact digest" "$out"
+out=$(AGY_DELEGATE=/nonexistent "$MEDIA" "$MDIR/demo.mp4" --print-command 2>/dev/null); rc=$?
+check "media asks for VISUALS on video" 0 "$rc" "VISUALS" "$out"
+out=$(AGY_DELEGATE=/nonexistent "$MEDIA" "$MDIR/clip.wav" "the pricing numbers" --print-command 2>/dev/null); rc=$?
+check "media threads the focus into the prompt" 0 "$rc" "the pricing numbers" "$out"
+# format pre-flight: m4a is mishandled by agy -> exit 5 with a conversion hint
+out=$("$MEDIA" "$MDIR/memo.m4a" 2>&1); rc=$?
+check "media blocks unsupported .m4a -> exit 5" 5 "$rc" "not reliably supported" "$out"
+out=$("$MEDIA" "$MDIR/notes.txt" 2>&1); rc=$?
+check "media rejects a non-media extension -> exit 5" 5 "$rc" "unrecognized media extension" "$out"
+out=$("$MEDIA" "$MDIR/nope.wav" 2>&1); rc=$?
+check "media missing file -> exit 4" 4 "$rc" "file not found" "$out"
+out=$("$MEDIA" 2>&1); rc=$?
+check "media with no args -> exit 1 (friendly)" 1 "$rc" "no media file given" "$out"
 
 echo "== agy-trace.sh (subagent trajectory reader) =="
 TRACE="$ROOT/scripts/agy-trace.sh"
@@ -565,7 +589,7 @@ for s in ("hooks/check-agy.sh", "hooks/inject-policy.sh", "hooks/validate-delega
 
 # bin/ entrypoints exist + executable (issue #11: $CLAUDE_PLUGIN_ROOT isn't exported
 # to model-run Bash, so commands/skill must call these bare names on the PATH)
-for b in ("agy-delegate", "agy-job", "agy-cost-compare", "agy-doctor", "cloud-debug", "agy-trace", "measure-session"):
+for b in ("agy-delegate", "agy-job", "agy-cost-compare", "agy-doctor", "cloud-debug", "agy-trace", "measure-session", "agy-media"):
     need(os.access(p("bin", b), os.X_OK), "bin entrypoint missing/not executable: bin/" + b)
 
 # regression guard: commands & skill must NOT invoke $CLAUDE_PLUGIN_ROOT/scripts/* — that


### PR DESCRIPTION
Claude Code can't hear audio or watch video, and doing it locally means an ffmpeg + speech-model stack. Gemini is natively multimodal — so delegate the *perception* to agy and keep the judgment in Claude.

**Verified end to end on agy 1.1.7:** audio transcribed; video analyzed with per-scene visuals + on-screen text + speech. No local transcription stack required.

## The differentiator: cost discipline is built in

agy writes the **full timestamped transcript to a file** and returns only a compact **digest** (summary · timestamped outline · key points · quotes with `[mm:ss]` · action items · visuals · uncertainty notes).

A 1-hour recording is ~10k words — exactly the `cache_read` blow-up this plugin exists to avoid — so it **never enters the conductor's context**. Claude reads *slices* of the transcript on demand to verify.

## Format pre-flight (a real trap, pre-empted)

agy's media handling is narrower than the Gemini API. Measured:

| works | fails |
|---|---|
| `wav mp3 flac ogg opus` · `mp4 mov webm` · `png jpg webp` | **`.m4a` / `.aiff`** — inconsistently ("invalid argument" or a hang) |

`.m4a` is what voice memos produce, and Gemini itself accepts it — this is an **agy-side gap**. Rather than surfacing that cryptic failure, the engine checks the extension first, exits `5` with the exact conversion one-liner, and `--convert` does it for you (macOS `afconvert`, else `ffmpeg`).

## Verification framing

The digest must flag inaudible passages and uncertain names/numbers; the command tells Claude to treat those as **unverified** and check the transcript slice (`grep` the timestamp) before relying on them. The engine warns if agy returns a digest without actually writing the transcript file.

## What's in the diff
- `scripts/agy-media.sh` + `bin/agy-media` (engine + PATH shim), `commands/media.md` (the conductor command)
- SKILL: new SDLC routing row + a recipe; README: feature bullet, command table, tree; `doctor` covers the new script/shim
- Prompt text kept ASCII — bash 3.2's `printf %q` mangles non-ASCII, which made `--print-command` output look binary to `grep`

## Verification
- **145 tests pass** (+11: dry-run digest contract, `--yolo`, transcript path, VISUALS on video, focus threading, `.m4a` → exit 5, non-media → 5, missing → 4, no-args → 1)
- shellcheck clean · `claude plugin validate` passes · live-verified on agy 1.1.7