### PR TITLE
fix: JSON-mode probe could silently disable structured output (SIGPIP…

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.21.1
+- **Fix: the JSON-mode capability probe could silently disable structured output
+  (SIGPIPE race).** `agy-delegate.sh` probed support with
+  `agy --help 2>&1 | grep -q -- '--output-format'`. `grep -q` exits at the first match and
+  closes the pipe, so `agy --help` can die of **SIGPIPE (141)**; under `set -o pipefail`
+  the whole pipeline reads as *failed*, JSON mode stays off, and **no `AGY_USAGE` line is
+  emitted** — which is indistinguishable from "no delegation happened". Measured on a
+  loaded container during a benchmark run: **~75% of calls** lost their usage line
+  (2/25 locally under no load). The probe now captures `agy --help` once into a variable
+  and matches with a shell glob — no pipe, no `grep`, no race. Regression tests assert
+  both the absence of the pipe and 20 stable probes.
+  *(Found by @yuting0624's benchmark harness — exactly the "silent success" failure class
+  this plugin exists to catch elsewhere.)*
+- **Docs: corrected the `AGY_USAGE` accounting semantics.** `total = input + output`
+  (`thinking` is inside `output`), and **`cache_read` is a separate counter — not part of
+  `total`, and not a subset of `input`**: in an agentic delegation it can far exceed
+  `input` (measured 1,356,694 vs 243,117). Price the Gemini side as three separate terms.
+  This is the opposite convention from the Claude/Harbor side, where cache-read tokens
+  *are* an inner subset of the input total. An earlier note in 0.21.0 stated the subset
+  reading; that was over-concluded from a sample where `cache_read < input`.
+
 ## 0.21.0
 - **Structured output (agy 1.1.8): reliable failure classification + real executor token
   usage.** agy 1.1.8 shipped `--output-format json` — the thing we'd tracked as "not

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -258,10 +258,17 @@ raw_so="${CLAUDE_PLUGIN_OPTION_STRUCTURED_OUTPUT:-on}"
 case "$(printf '%s' "$raw_so" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
   off|false|0|no|disabled) ;;
   *)
-    if [ "$PRINT_CMD" -ne 1 ] && command -v python3 >/dev/null 2>&1 \
-       && agy --help 2>&1 | grep -q -- '--output-format'; then
-      JSON_MODE=1
-      ARGS+=(--output-format json)
+    if [ "$PRINT_CMD" -ne 1 ] && command -v python3 >/dev/null 2>&1; then
+      # Capability probe. Deliberately NOT `agy --help | grep -q`: `grep -q` exits at
+      # the first match and closes the pipe, so `agy --help` can die of SIGPIPE (141)
+      # and, under `set -o pipefail`, the whole pipeline reads as "failed" — silently
+      # disabling JSON mode. That race actually bit a benchmark run (~75% of calls on a
+      # loaded container), and it is indistinguishable from "no delegation happened",
+      # which is the worst kind of failure. Capture once, match with a shell glob.
+      agy_help="$(agy --help 2>&1 || true)"
+      case "$agy_help" in
+        *--output-format*) JSON_MODE=1; ARGS+=(--output-format json) ;;
+      esac
     fi ;;
 esac
 

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.21.0
+version: 0.21.1
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -88,6 +88,15 @@ token usage (input / output / thinking / **cache_read**) is reported as an `AGY_
 {...}` line on stderr — so the Gemini side of a delegation can finally be *measured*, not
 estimated. Older agy (or no `python3`) transparently falls back to the plain-text path;
 force it with the `structured_output` option.
+
+> **Accounting semantics for `AGY_USAGE` (verified — get this wrong and your cost math
+> is wrong).** `total = input + output` (and `thinking` is *inside* `output`).
+> **`cache_read` is a separate counter: it is NOT part of `total`, and it is not a subset
+> of `input`** — in an agentic delegation it routinely *exceeds* `input` (measured:
+> `cache_read` 1,356,694 vs `input` 243,117 in one delegation). So price the Gemini side
+> as `input×in_rate + output×out_rate + cache_read×cached_rate`, three separate terms.
+> This differs from the Claude/Harbor side, where cache-read tokens *are* an inner subset
+> of the reported input total — don't carry one convention over to the other.
 
 **Two ways to delegate.** Call the wrapper directly (above), or — when you want file
 generation to happen entirely on Gemini with **zero Claude tokens spent writing** — hand

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -134,6 +134,24 @@ check "agy bad --model -> exit 14 + signal" 14 "$rc" "MODEL_UNAVAILABLE" "$out"
 # agy >= 1.1.8 structured output: used internally, stdout contract unchanged
 out=$(STUB_JSON_CAPABLE=1 STUB_MODE=json_ok "$DELEGATE" "hi" 2>/dev/null); rc=$?
 check "json mode: stdout carries the response text (not the envelope)" 0 "$rc" "JSONBODY" "$out"
+# Regression: the capability probe must not pipe into `grep -q`. That closes the pipe on
+# the first match, `agy --help` can die of SIGPIPE, and under `set -o pipefail` the probe
+# silently reads as "unsupported" -> JSON mode off with no AGY_USAGE, indistinguishable
+# from "no delegation happened". Observed at ~75% failure on a loaded container.
+if sed 's/#.*//' "$DELEGATE" | grep -qE 'agy --help[^|]*\| *grep'; then
+  echo "FAIL: capability probe pipes agy --help into grep (SIGPIPE race under pipefail)"; FAIL=$((FAIL+1));
+else echo "ok: capability probe avoids the grep pipe (no SIGPIPE race)"; PASS=$((PASS+1)); fi
+# Under load the probe must still be deterministic: run the real gate shape 20x.
+probe_off=0
+for _ in $(seq 1 20); do
+  STUB_JSON_CAPABLE=1 bash -c '
+    set -euo pipefail
+    h="$(agy --help 2>&1 || true)"
+    case "$h" in *--output-format*) exit 0 ;; esac
+    exit 1' >/dev/null 2>&1 || probe_off=$((probe_off+1))
+done
+if [ "$probe_off" -eq 0 ]; then echo "ok: capability probe stable over 20 runs"; PASS=$((PASS+1));
+else echo "FAIL: capability probe flaked $probe_off/20 times"; FAIL=$((FAIL+1)); fi
 if printf '%s' "$out" | grep -q 'conversation_id'; then
   echo "FAIL: json envelope leaked to stdout"; FAIL=$((FAIL+1));
 else echo "ok: json envelope does not leak to stdout"; PASS=$((PASS+1)); fi


### PR DESCRIPTION
…E race) (0.21.1)

agy-delegate.sh probed for --output-format support with

    agy --help 2>&1 | grep -q -- '--output-format'

`grep -q` exits at the first match and closes the pipe, so `agy --help` can die of SIGPIPE (141); under `set -o pipefail` the pipeline reads as failed, JSON mode stays off, and no AGY_USAGE line is emitted -- indistinguishable from "no delegation happened". Measured ~75% failure on a loaded container during a benchmark run (2/25 locally under no load; reproduced here at 1/25).

The probe now captures `agy --help` once into a variable and matches with a shell glob: no pipe, no grep, no race. Regression tests assert both that the pipe is gone (comments excluded) and that 20 consecutive probes are stable.

Also corrects the AGY_USAGE accounting semantics in the skill: total = input + output (thinking is inside output), and cache_read is a SEPARATE counter -- not part of total, and not a subset of input; in an agentic delegation it can far exceed input (measured 1,356,694 vs 243,117). Price the Gemini side as three separate terms. This is the opposite convention from the Claude/Harbor side. The 0.21.0 note claiming the subset reading was over-concluded from a sample where cache_read happened to be smaller than input.

155 tests pass; shellcheck clean; plugin validate passes; live-verified that AGY_USAGE is emitted again on agy 1.1.8.