### PR TITLE
ci: enable show_full_output on the Claude review workflows

### DIFF
--- a/.github/workflows/claude-review-external.yml
+++ b/.github/workflows/claude-review-external.yml
@@ -50,6 +50,9 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Surfaces the real API error instead of a bare is_error:true (the action
+          # suppresses it by default). Keep on until the review path is proven stable.
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Surfaces the real API error instead of a bare is_error:true (the action
+          # suppresses it by default). Keep on until the review path is proven stable.
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
The review run on #34 failed with a bare `is_error: true` and no diagnostic:

```
{"type":"result","subtype":"success","is_error":true,
 "duration_ms":1999,"num_turns":1,"total_cost_usd":0,"permission_denials_count":0}
```

The action suppresses the underlying error unless `show_full_output` is set — its own log says so (*"Rerun in debug mode or enable `show_full_output: true` ... for full output"*). This turns it on for both review workflows so the real API error is visible.

**Sequencing note:** the action requires the workflow file to match the version on the default branch, so this change only takes effect **after it's merged** — its own PR run will be skipped by that validation (same as #33). Once merged, rebase #34 to pick it up.

Can be removed once the review path is proven stable.