### PR TITLE
fix: route agy stdout through a temp file, not a capture pipe (#37)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.22.1
+- **Fix: every wrapper hung forever when stdio MCP servers were configured.** Reported by
+  @rickberguer (#37) on macOS with a healthy, authenticated agy. `agy`'s stdio MCP children
+  **inherit its stdout and outlive it**, so they hold the write end of a command-substitution
+  pipe open and `OUT="$(agy ...)"` never sees EOF. **The wall-clock guard cannot help**: it
+  kills `agy`, not the grandchildren — which is why this presented as an unbounded hang
+  despite the timeout that exists for exactly this class of problem. Isolated cleanly by the
+  reporter: same machine, only `mcp_config.json` changed — 16 servers hung on a pipe and
+  returned in 6.5s to a file; 0 servers returned in 5.6s either way.
+  Blast radius was everything. `doctor` hung inside `agy_guard`, so `/antigravity:setup`
+  reported a broken or unauthenticated CLI while auth was fine, and `agy-delegate` hung on
+  every call, taking `agy-job`, `delegate`, `review`, `research` and the delegate subagent
+  with it.
+  `agy` stdout now goes to a temp file, which children inherit harmlessly — the main call,
+  and the `agy --help` capability probe, which had the same hazard and was not in the report
+  (that line has now been wrong twice, for two unrelated reasons; see 0.21.1). Cleanup is
+  folded into the existing `EXIT` trap, so it also happens on the timeout path where a
+  trailing `rm -f` never runs. `doctor`'s `agy_guard` redirects internally and `cat`s at the
+  end, so `cat` is the only writer to the caller's pipe and it always exits. `agy-job.sh`
+  already redirected to files and needed no change.
+  Guarded by shape, not symptom — a hang cannot be asserted on cheaply and the next refactor
+  is where it returns: tests reject any command-substitution capture of `agy` in either
+  script, plus a stub that reproduces the inherited-stdout hang and shows the file form
+  returning. All verified to fail against the unfixed code.
+- **`doctor` now names stdio MCP servers when `agy models` times out.** The precondition is
+  invisible from the plugin's side and currently reads as an auth failure, which sends people
+  off re-authenticating for nothing. Counts **both** sources agy documents — the global
+  `~/.gemini/config/mcp_config.json` *and* `plugins/<name>/mcp_config.json` — because a
+  diagnostic that undercounts fails silently, for exactly the person it exists for. Remote
+  servers are identified by `serverUrl` on agy 1.1.9, not the `url`/`httpUrl` other MCP
+  clients use. The hint describes agy **blocking internally on a server that never finishes
+  connecting** — which reproduces with stdout on a file and is what can still hang here —
+  not the pipe mechanism this release removes.
+
 ## 0.22.0
 - **Docs: the number of delegations is the lever — batch them.** Benchmarking this
   plugin (Opus 5 conductor · Gemini 3.6 Flash High executor · agy 1.1.8 · n=3/arm, cold

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -47,6 +47,43 @@ hang" instead of the misleading "not authenticated".
 
 ---
 
+## Everything hangs forever, and `/antigravity:setup` says the CLI is broken
+
+**Symptom:** `agy models` and every delegation never return. `agy-doctor` reports a hung or
+unauthenticated CLI — but typing `agy models` yourself works fine. macOS and Linux, not just
+Windows.
+
+**Cause:** you have **stdio MCP servers configured** and a plugin build older than 0.22.1
+([#37](https://github.com/yuting0624/antigravity-for-claude-code/issues/37)). agy's stdio MCP
+children **inherit its stdout and outlive agy**. A shell command substitution only returns
+once *every* holder of the pipe's write end closes it, so `OUT="$(agy ...)"` waits forever on
+children that are still alive. The wall-clock guard cannot rescue this: `timeout` kills
+`agy`, not the grandchildren.
+
+The one-line test, from the original report — same machine, only the config changed:
+
+```bash
+# stdout to a FILE — returns in ~6s
+timeout 60 agy -p "Reply with exactly: PONG" > /tmp/out.txt 2>/dev/null </dev/null
+
+# stdout to a PIPE (what the wrappers used to do) — hangs
+timeout 90 bash -c 'O="$(timeout 60 agy -p "Reply with exactly: PONG" 2>/dev/null)"' </dev/null
+```
+
+**Fix: update to 0.22.1 or later.** agy's stdout now goes to a temp file, which children
+inherit harmlessly. Check with `agy-doctor` (it prints the plugin version).
+
+### It still hangs on 0.22.1+
+
+Then it is a **different mechanism**, and one the plugin cannot fix: agy waits on its MCP
+servers at startup, so a server that never finishes connecting blocks `agy` itself — this
+reproduces even with stdout on a file. `agy-doctor` now tells you how many stdio MCP servers
+you have when `agy models` times out.
+
+To confirm, check agy's log (`~/.gemini/antigravity-cli/log/cli-*.log`) for a server that
+never reports ready, or move `~/.gemini/config/mcp_config.json` aside temporarily. Note agy
+loads MCP servers from **two** places — that file and `~/.gemini/config/plugins/*/mcp_config.json`.
+
 ## WSL: delegation works but is absurdly slow (20s+ for trivial calls)
 
 **Cause:** your repo lives on a Windows mount (`/mnt/c/...`). agy reads `--dir` workspaces

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -288,6 +288,13 @@ for d in "${ADD_DIRS[@]:-}"; do [ -n "$d" ] && ARGS+=(--add-dir "$d"); done
 # an unguarded call is an unguarded call.
 TO_CMD="$(timeout_cmd || true)"
 
+# One trap for every temp file this script makes, installed before the first one
+# exists. Declaring them empty up front means the probe's file is covered too —
+# it used to be cleaned by a trailing `rm -f`, which a SIGINT during the probe
+# skips. `rm -f ""` is a silent no-op, so the unset ones cost nothing.
+HELPF=""; ERR=""; OUTF=""
+trap 'rm -f "$HELPF" "$ERR" "$OUTF" 2>/dev/null' EXIT
+
 JSON_MODE=0
 raw_so="${CLAUDE_PLUGIN_OPTION_STRUCTURED_OUTPUT:-on}"
 case "$(printf '%s' "$raw_so" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
@@ -333,7 +340,6 @@ ERR="$(mktemp "${TMPDIR:-/tmp}/agy-delegate.XXXXXX")"
 # waiting for EOF even after `timeout` kills agy itself (issue #37). A regular
 # file is inherited harmlessly.
 OUTF="$(mktemp "${TMPDIR:-/tmp}/agy-out.XXXXXX")"
-trap 'rm -f "$ERR" "$OUTF"' EXIT
 
 # Wall-clock guard: on a non-TTY caller (the whole point of this wrapper), agy can
 # hard-hang before its own --print-timeout engages (notably native Windows without

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -241,7 +241,7 @@ if [ "$YOLO" -eq 0 ] && [ "$PRINT_CMD" -ne 1 ]; then
   shopt -s nocasematch
   case "$PROMPT" in
     *implement*|*scaffold*|*migrate*|*refactor*|*"write the file"*|*"create the file"*|*"edit the file"*)
-      echo "agy-delegate: note: this looks like a write task but --yolo is not set — headless agy will NOT write to your workspace without it (it describes / scratch-diverts / soft-denies depending on version, while the run still 'succeeds'; issue #10). Add --yolo and run on a dedicated branch, then verify with git status." >&2 ;;
+      echo "agy-delegate: note: this looks like a write task but --yolo is not set — headless agy will NOT write to your workspace without it (it describes / scratch-diverts / soft-denies depending on version, while the run still 'succeeds'; issue #10). Add --yolo and run on a dedicated branch, then verify with git status. (If ~/.gemini/antigravity-cli/settings.json has a matching write_file(<dir>) rule under permissions.allow, writes to that dir already work without --yolo and you can ignore this.)" >&2 ;;
   esac
   shopt -u nocasematch
 fi
@@ -293,7 +293,11 @@ case "$(printf '%s' "$raw_so" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
       # disabling JSON mode. That race actually bit a benchmark run (~75% of calls on a
       # loaded container), and it is indistinguishable from "no delegation happened",
       # which is the worst kind of failure. Capture once, match with a shell glob.
-      agy_help="$(agy --help 2>&1 || true)"
+      # Same pipe hazard as the main call (issue #37): route via a temp file so
+      # inherited MCP children can never hold the capture pipe open.
+      HELPF="$(mktemp "${TMPDIR:-/tmp}/agy-help.XXXXXX")"
+      agy --help >"$HELPF" 2>&1 || true
+      agy_help="$(cat "$HELPF" 2>/dev/null)"; rm -f "$HELPF"
       case "$agy_help" in
         *--output-format*) JSON_MODE=1; ARGS+=(--output-format json) ;;
       esac
@@ -310,7 +314,12 @@ fi
 # Per-invocation temp file for stderr (mktemp avoids the race + symlink risk of a
 # fixed /tmp path when multiple delegations run concurrently). Cleaned up on exit.
 ERR="$(mktemp "${TMPDIR:-/tmp}/agy-delegate.XXXXXX")"
-trap 'rm -f "$ERR"' EXIT
+# stdout goes to a file too, never a command-substitution pipe: agy's stdio MCP
+# children inherit our stdout and can outlive agy, so `$(agy ...)` blocks forever
+# waiting for EOF even after `timeout` kills agy itself (issue #37). A regular
+# file is inherited harmlessly.
+OUTF="$(mktemp "${TMPDIR:-/tmp}/agy-out.XXXXXX")"
+trap 'rm -f "$ERR" "$OUTF"' EXIT
 
 # Wall-clock guard: on a non-TTY caller (the whole point of this wrapper), agy can
 # hard-hang before its own --print-timeout engages (notably native Windows without
@@ -330,12 +339,13 @@ fi
 set +e
 if [ -n "$TO_CMD" ]; then
   # --kill-after sends SIGKILL if agy ignores the initial SIGTERM (defensive).
-  OUT="$("$TO_CMD" --kill-after=10 "$TO_SECS" agy "${ARGS[@]}" -p "$PROMPT" < /dev/null 2>"$ERR")"
+  "$TO_CMD" --kill-after=10 "$TO_SECS" agy "${ARGS[@]}" -p "$PROMPT" < /dev/null >"$OUTF" 2>"$ERR"
   RC=$?
 else
-  OUT="$(agy "${ARGS[@]}" -p "$PROMPT" < /dev/null 2>"$ERR")"
+  agy "${ARGS[@]}" -p "$PROMPT" < /dev/null >"$OUTF" 2>"$ERR"
   RC=$?
 fi
+OUT="$(cat "$OUTF" 2>/dev/null)"
 set -e
 
 # --- unwrap the structured envelope (JSON mode) --------------------------------

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -241,7 +241,7 @@ if [ "$YOLO" -eq 0 ] && [ "$PRINT_CMD" -ne 1 ]; then
   shopt -s nocasematch
   case "$PROMPT" in
     *implement*|*scaffold*|*migrate*|*refactor*|*"write the file"*|*"create the file"*|*"edit the file"*)
-      echo "agy-delegate: note: this looks like a write task but --yolo is not set — headless agy will NOT write to your workspace without it (it describes / scratch-diverts / soft-denies depending on version, while the run still 'succeeds'; issue #10). Add --yolo and run on a dedicated branch, then verify with git status. (If ~/.gemini/antigravity-cli/settings.json has a matching write_file(<dir>) rule under permissions.allow, writes to that dir already work without --yolo and you can ignore this.)" >&2 ;;
+      echo "agy-delegate: note: this looks like a write task but --yolo is not set — headless agy will NOT write to your workspace without it (it describes / scratch-diverts / soft-denies depending on version, while the run still 'succeeds'; issue #10). Add --yolo and run on a dedicated branch, then verify with git status." >&2 ;;
   esac
   shopt -u nocasematch
 fi

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -297,7 +297,8 @@ case "$(printf '%s' "$raw_so" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
       # inherited MCP children can never hold the capture pipe open.
       HELPF="$(mktemp "${TMPDIR:-/tmp}/agy-help.XXXXXX")"
       agy --help >"$HELPF" 2>&1 || true
-      agy_help="$(cat "$HELPF" 2>/dev/null)"; rm -f "$HELPF"
+      # `|| true` so the assignment cannot fail under `set -e` and skip the rm.
+      agy_help="$(cat "$HELPF" 2>/dev/null || true)"; rm -f "$HELPF"
       case "$agy_help" in
         *--output-format*) JSON_MODE=1; ARGS+=(--output-format json) ;;
       esac

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -281,6 +281,13 @@ for d in "${ADD_DIRS[@]:-}"; do [ -n "$d" ] && ARGS+=(--add-dir "$d"); done
 #   * the user hasn't opted out (structured_output=off).
 # NOTE: agy 1.1.8 emits a RAW newline inside the "response" string, which strict
 # JSON parsers reject — so we parse with strict=False. (Reported upstream.)
+# Resolved BEFORE the capability probe below, not just before the main call: the
+# probe was the one unbounded `agy` invocation left in this script. Measured, it
+# returns in ~0.08s — but doctor's own hint documents a hang this release does NOT
+# fix (agy blocking internally while an MCP server never finishes connecting), and
+# an unguarded call is an unguarded call.
+TO_CMD="$(timeout_cmd || true)"
+
 JSON_MODE=0
 raw_so="${CLAUDE_PLUGIN_OPTION_STRUCTURED_OUTPUT:-on}"
 case "$(printf '%s' "$raw_so" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
@@ -296,7 +303,13 @@ case "$(printf '%s' "$raw_so" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
       # Same pipe hazard as the main call (issue #37): route via a temp file so
       # inherited MCP children can never hold the capture pipe open.
       HELPF="$(mktemp "${TMPDIR:-/tmp}/agy-help.XXXXXX")"
-      agy --help >"$HELPF" 2>&1 || true
+      # 15s is ~180x the measured time; it fires only on a real hang, and losing
+      # JSON mode is the right failure — the plain-text path still works.
+      if [ -n "$TO_CMD" ]; then
+        "$TO_CMD" --kill-after=5 15 agy --help >"$HELPF" 2>&1 || true
+      else
+        agy --help >"$HELPF" 2>&1 || true
+      fi
       # `|| true` so the assignment cannot fail under `set -e` and skip the rm.
       agy_help="$(cat "$HELPF" 2>/dev/null || true)"; rm -f "$HELPF"
       case "$agy_help" in
@@ -327,7 +340,6 @@ trap 'rm -f "$ERR" "$OUTF"' EXIT
 # a ConPTY — see issue #6). Wrap in GNU `timeout`/`gtimeout` when available so we
 # always return instead of hanging forever. `timeout` exits 124 on kill -> map to
 # our TIMEOUT (12) and emit the structured signal, so orchestrators react cleanly.
-TO_CMD="$(timeout_cmd || true)"
 TO_SECS="$(outer_timeout_secs "$TIMEOUT")"
 
 if on_windows_native && [ -z "$TO_CMD" ]; then

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -63,20 +63,33 @@ agy_guard() { # usage: agy_guard <secs> <agy-args...>
 # the plugin's side, so surface them: a hang there is a config symptom, not bad auth.
 # Prints the count and returns 0 when at least one is configured.
 has_stdio_mcp() {
-  local cfg="${HOME}/.gemini/config/mcp_config.json"
-  [ -r "$cfg" ] || return 1
   command -v python3 >/dev/null 2>&1 || return 1
+  # TWO sources, per agy's own embedded docs:
+  #   "Global Configuration: ~/.gemini/config/mcp_config.json (applies to all ...)"
+  #   "Plugin Configuration: plugins/<plugin_name>/mcp_config.json (active ...)"
+  # Counting only the global file undercounts, and this is a diagnostic — a miss
+  # is silent, so it fails to help exactly the person who needs it.
+  local root="${AGY_CONFIG_DIR:-${HOME}/.gemini/config}"
+  local files=("$root/mcp_config.json")
+  local p
+  for p in "$root"/plugins/*/mcp_config.json; do
+    [ -r "$p" ] && files+=("$p")
+  done
   python3 -c '
 import json, sys
-try:
-    servers = (json.load(open(sys.argv[1])) or {}).get("mcpServers") or {}
-except Exception:
-    sys.exit(1)
-# stdio servers are launched as a local process ("command"), unlike url/httpUrl ones.
-n = sum(1 for v in servers.values() if isinstance(v, dict) and v.get("command"))
+n = 0
+for path in sys.argv[1:]:
+    try:
+        servers = (json.load(open(path)) or {}).get("mcpServers") or {}
+    except Exception:
+        continue
+    # A stdio server is launched as a local process, so it carries "command"
+    # (verified against agy 1.1.9: remote servers use "serverUrl", not the
+    # "url"/"httpUrl" spelling other MCP clients use — do not match on those).
+    n += sum(1 for v in servers.values() if isinstance(v, dict) and v.get("command"))
 print(n)
 sys.exit(0 if n else 1)
-' "$cfg" 2>/dev/null
+' "${files[@]}" 2>/dev/null
 }
 
 # True on native Windows (Git Bash/MSYS/Cygwin), NOT WSL — where headless agy hangs.
@@ -112,9 +125,14 @@ if command -v agy >/dev/null 2>&1; then
   if [ "$AGY_TIMED_OUT" -eq 1 ]; then
     bad "\`agy models\` hung and was killed after 20s — this is NOT an auth problem"
     if MCP_N="$(has_stdio_mcp)"; then
-      info "you have $MCP_N stdio MCP server(s) configured in ~/.gemini/config/mcp_config.json."
-      info "those children inherit agy's stdout and can outlive it, holding a capture pipe open (issue #37)."
-      info "if this persists on a current plugin build, disable them temporarily to confirm the cause."
+      # NOT the issue-37 mechanism. That one was MCP children holding a capture
+      # PIPE open, and there is no pipe left to hold — agy's stdout goes to a
+      # file now. What can still hang here is agy blocking INTERNALLY while a
+      # configured MCP server never finishes connecting, which reproduces even
+      # with stdout on a file and looks identical from the outside.
+      info "you have $MCP_N stdio MCP server(s) configured (~/.gemini/config/mcp_config.json and plugins/*/mcp_config.json)."
+      info "agy waits on its MCP servers at startup, so one that never finishes connecting blocks \`agy models\` itself."
+      info "check the agy log for a server that never reports ready, or disable them temporarily to confirm the cause."
     fi
     info "agy hangs when run headless with no TTY/console (0-byte log, no output)."
     if on_windows_native; then

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -43,12 +43,40 @@ fi
 # caller inspects the RETURN CODE (not a global) because this runs inside a
 # command-substitution subshell, where a global assignment would NOT propagate.
 agy_guard() { # usage: agy_guard <secs> <agy-args...>
+  # Redirect agy's stdout to a file and `cat` it at the end. Callers capture this with
+  # $(...), and agy's stdio MCP children inherit whatever stdout they are handed — if
+  # that is the capture pipe they can hold it open forever and the substitution never
+  # returns, even after `timeout` kills agy (issue #37). `cat` always exits.
   local secs="$1"; shift
+  local f rc
+  f="$(mktemp "${TMPDIR:-/tmp}/agy-guard.XXXXXX")"
   if [ -n "$TO_CMD" ]; then
-    "$TO_CMD" --kill-after=5 "$secs" agy "$@"
-    return $?
+    "$TO_CMD" --kill-after=5 "$secs" agy "$@" >"$f" 2>/dev/null; rc=$?
+  else
+    agy "$@" >"$f" 2>/dev/null; rc=$?
   fi
-  agy "$@"
+  cat "$f"; rm -f "$f"
+  return $rc
+}
+
+# stdio MCP servers are the precondition for the issue-37 hang and are invisible from
+# the plugin's side, so surface them: a hang there is a config symptom, not bad auth.
+# Prints the count and returns 0 when at least one is configured.
+has_stdio_mcp() {
+  local cfg="${HOME}/.gemini/config/mcp_config.json"
+  [ -r "$cfg" ] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 -c '
+import json, sys
+try:
+    servers = (json.load(open(sys.argv[1])) or {}).get("mcpServers") or {}
+except Exception:
+    sys.exit(1)
+# stdio servers are launched as a local process ("command"), unlike url/httpUrl ones.
+n = sum(1 for v in servers.values() if isinstance(v, dict) and v.get("command"))
+print(n)
+sys.exit(0 if n else 1)
+' "$cfg" 2>/dev/null
 }
 
 # True on native Windows (Git Bash/MSYS/Cygwin), NOT WSL — where headless agy hangs.
@@ -83,6 +111,11 @@ if command -v agy >/dev/null 2>&1; then
   { [ "$AGY_RC" -eq 124 ] || [ "$AGY_RC" -eq 137 ]; } && AGY_TIMED_OUT=1
   if [ "$AGY_TIMED_OUT" -eq 1 ]; then
     bad "\`agy models\` hung and was killed after 20s — this is NOT an auth problem"
+    if MCP_N="$(has_stdio_mcp)"; then
+      info "you have $MCP_N stdio MCP server(s) configured in ~/.gemini/config/mcp_config.json."
+      info "those children inherit agy's stdout and can outlive it, holding a capture pipe open (issue #37)."
+      info "if this persists on a current plugin build, disable them temporarily to confirm the cause."
+    fi
     info "agy hangs when run headless with no TTY/console (0-byte log, no output)."
     if on_windows_native; then
       info "native Windows: agy needs a real console (ConPTY). Run delegation from WSL/macOS/Linux."

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.22.0
+version: 0.22.1
 ---
 
 # Antigravity for Claude Code — hybrid SDLC

--- a/tests/repro-issue37-mcp-pipe.sh
+++ b/tests/repro-issue37-mcp-pipe.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Reproduce issue #37: a stdio-MCP-like child inherits agy's stdout and outlives it.
+# The child holds the write end of any capture pipe open -> $(...) never sees EOF.
+BIN="$(mktemp -d)"
+cat > "$BIN/agy" <<'EOF'
+#!/usr/bin/env bash
+# Simulate agy: spawn a long-lived "MCP server" child that inherits stdout,
+# print the answer, then exit quickly (like real agy: ~6s).
+sleep 60 &          # <- the MCP child, inherits our stdout, outlives us
+echo "PONG"
+exit 0
+EOF
+chmod +x "$BIN/agy"
+export PATH="$BIN:$PATH"
+
+echo "--- BEFORE (command substitution, as shipped) ---"
+start=$(date +%s)
+timeout 10 bash -c 'OUT="$(agy -p "ping" </dev/null 2>/dev/null)"; echo "got:[$OUT]"'
+rc=$?
+echo "rc=$rc elapsed=$(( $(date +%s) - start ))s $( [ $rc -eq 124 ] && echo '<-- HUNG (killed at 10s)' )"
+
+echo "--- AFTER (temp file, the fix) ---"
+start=$(date +%s)
+timeout 10 bash -c 'F="$(mktemp)"; agy -p "ping" </dev/null >"$F" 2>/dev/null; OUT="$(cat "$F")"; rm -f "$F"; echo "got:[$OUT]"'
+rc=$?
+echo "rc=$rc elapsed=$(( $(date +%s) - start ))s $( [ $rc -eq 0 ] && echo '<-- RETURNED' )"
+rm -rf "$BIN"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -185,8 +185,17 @@ chmod +x "$MCPBIN/agy"
 if PATH="$MCPBIN:$PATH" timeout 5 bash -c 'O="$(agy -p x </dev/null 2>/dev/null)"' >/dev/null 2>&1; then
   echo "FAIL: stub did not reproduce the pipe hang — the test no longer proves anything"; FAIL=$((FAIL+1));
 else echo "ok: stub reproduces the inherited-stdout pipe hang"; PASS=$((PASS+1)); fi
-out=$(PATH="$MCPBIN:$PATH" timeout 5 bash -c 'f="$(mktemp)"; agy -p x </dev/null >"$f" 2>/dev/null; cat "$f"; rm -f "$f"' 2>/dev/null)
-check "the file form returns against the same stub" 0 "$?" "PONG" "$out"
+# NOT `out`: the pre-existing json-envelope check below reads that variable, and
+# clobbering it here made that assertion pass unconditionally — silently, with PASS
+# still incrementing. A test that passes for the wrong reason is worse than no test.
+mcp_out=$(PATH="$MCPBIN:$PATH" timeout 5 bash -c 'f="$(mktemp)"; agy -p x </dev/null >"$f" 2>/dev/null; cat "$f"; rm -f "$f"' 2>/dev/null)
+check "the file form returns against the same stub" 0 "$?" "PONG" "$mcp_out"
+# Liveness first: a negative assertion on an empty variable passes for free, and
+# this one sat 50 lines from where `out` is set — far enough that an insertion in
+# between silently emptied it once already.
+if [ -z "$out" ]; then
+  echo "FAIL: \$out is empty at the envelope check — the assertion below proves nothing"; FAIL=$((FAIL+1));
+else echo "ok: \$out still holds the json_ok reply at the envelope check"; PASS=$((PASS+1)); fi
 if printf '%s' "$out" | grep -q 'conversation_id'; then
   echo "FAIL: json envelope leaked to stdout"; FAIL=$((FAIL+1));
 else echo "ok: json envelope does not leak to stdout"; PASS=$((PASS+1)); fi

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -157,6 +157,18 @@ done
 if [ "$probe_off" -eq 0 ]; then echo "ok: capability probe stable over 20 runs"; PASS=$((PASS+1));
 else echo "FAIL: capability probe flaked $probe_off/20 times"; FAIL=$((FAIL+1)); fi
 
+# The --help probe must be wall-clock bounded like the main call. It was the one
+# unguarded `agy` invocation left: the timeout resolver used to be initialised
+# after it. A hang here is not hypothetical — doctor's own MCP hint documents a
+# blocking mode that survives the issue-37 fix.
+if sed 's/#.*//' "$DELEGATE" | grep -qE '"\$TO_CMD"[^|]*agy --help'; then
+  echo "ok: the --help capability probe is wall-clock bounded"; PASS=$((PASS+1));
+else echo "FAIL: --help probe runs unguarded (no timeout)"; FAIL=$((FAIL+1)); fi
+if [ "$(sed 's/#.*//' "$DELEGATE" | grep -n 'TO_CMD="\$(timeout_cmd' | cut -d: -f1)" \
+   -lt "$(sed 's/#.*//' "$DELEGATE" | grep -n 'agy --help' | head -1 | cut -d: -f1)" ]; then
+  echo "ok: the timeout resolver is initialised before the probe uses it"; PASS=$((PASS+1));
+else echo "FAIL: TO_CMD resolved after the --help probe — the guard is a no-op"; FAIL=$((FAIL+1)); fi
+
 # --- issue #37: never capture agy through a pipe ------------------------------
 # agy's stdio MCP children INHERIT its stdout and outlive it, so they hold the
 # write end of a command-substitution pipe open and `$(agy ...)` never sees EOF.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -156,6 +156,37 @@ for _ in $(seq 1 20); do
 done
 if [ "$probe_off" -eq 0 ]; then echo "ok: capability probe stable over 20 runs"; PASS=$((PASS+1));
 else echo "FAIL: capability probe flaked $probe_off/20 times"; FAIL=$((FAIL+1)); fi
+
+# --- issue #37: never capture agy through a pipe ------------------------------
+# agy's stdio MCP children INHERIT its stdout and outlive it, so they hold the
+# write end of a command-substitution pipe open and `$(agy ...)` never sees EOF.
+# The `timeout` guard cannot save this: it kills agy, not the grandchildren. The
+# only fix is to not use a pipe, so guard the shape rather than the symptom —
+# a hang cannot be asserted on cheaply, and the next refactor is where it comes
+# back. Both the main call and the --help probe were affected.
+if sed 's/#.*//' "$DELEGATE" | grep -qE '=[[:space:]]*"?\$\((\$?[A-Za-z_"]*TO_CMD"?[^)]*)?[[:space:]]*agy[[:space:]]'; then
+  echo "FAIL: agy captured through a command substitution (issue #37 pipe hang)"; FAIL=$((FAIL+1));
+else echo "ok: agy output is never captured through a pipe (issue #37)"; PASS=$((PASS+1)); fi
+if sed 's/#.*//' "$ROOT/scripts/doctor.sh" | grep -qE '^[[:space:]]*(agy|"\$TO_CMD")[^>|]*$' \
+   && ! grep -q 'cat "\$f"' "$ROOT/scripts/doctor.sh"; then
+  echo "FAIL: doctor's agy_guard writes to the caller's pipe (issue #37)"; FAIL=$((FAIL+1));
+else echo "ok: doctor's agy_guard redirects to a file, cat is the only pipe writer"; PASS=$((PASS+1)); fi
+# The mechanism itself, against a stub that behaves like agy+MCP: spawn a child
+# that inherits stdout and outlives the parent. Pipe form must hang; file form
+# must return. Bounded so a regression costs 5s, not the whole suite.
+MCPBIN="$TMP/mcpstub"; mkdir -p "$MCPBIN"
+cat > "$MCPBIN/agy" <<'STUB'
+#!/usr/bin/env bash
+sleep 30 &        # the "MCP server": inherits our stdout, outlives us
+echo "PONG"
+exit 0
+STUB
+chmod +x "$MCPBIN/agy"
+if PATH="$MCPBIN:$PATH" timeout 5 bash -c 'O="$(agy -p x </dev/null 2>/dev/null)"' >/dev/null 2>&1; then
+  echo "FAIL: stub did not reproduce the pipe hang — the test no longer proves anything"; FAIL=$((FAIL+1));
+else echo "ok: stub reproduces the inherited-stdout pipe hang"; PASS=$((PASS+1)); fi
+out=$(PATH="$MCPBIN:$PATH" timeout 5 bash -c 'f="$(mktemp)"; agy -p x </dev/null >"$f" 2>/dev/null; cat "$f"; rm -f "$f"' 2>/dev/null)
+check "the file form returns against the same stub" 0 "$?" "PONG" "$out"
 if printf '%s' "$out" | grep -q 'conversation_id'; then
   echo "FAIL: json envelope leaked to stdout"; FAIL=$((FAIL+1));
 else echo "ok: json envelope does not leak to stdout"; PASS=$((PASS+1)); fi

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -550,6 +550,35 @@ if printf '%s' "$out" | grep -q "tier model present: Gemini 3.5 Flash (High)"; t
   echo "ok: doctor matches default flash tier in slug format"; PASS=$((PASS+1));
 else echo "FAIL: doctor did not confirm the default flash tier present"; FAIL=$((FAIL+1)); fi
 
+echo "== doctor.sh stdio-MCP detection (issue #37 diagnostic) =="
+# The hint is diagnostic-only, so getting it wrong fails SILENTLY — it just never
+# helps the person it exists for. Pin the two things measured against agy 1.1.9:
+# stdio servers carry "command", remote ones carry "serverUrl" (not the
+# "url"/"httpUrl" spelling other MCP clients use), and plugin-scoped configs
+# count too — agy's own docs list global AND plugins/<name>/mcp_config.json.
+mcp_count() { # $1 = config root; echoes "<rc> <count>"
+  local n rc
+  n="$(AGY_CONFIG_DIR="$1" bash -c '
+    source_fn() { sed -n "/^has_stdio_mcp() {/,/^}/p" "$1"; }
+    eval "$(source_fn "'"$ROOT"'/scripts/doctor.sh")"
+    has_stdio_mcp' 2>/dev/null)"; rc=$?
+  printf '%s %s' "$rc" "${n:-0}"
+}
+MCPDIR="$TMP/mcp"; mkdir -p "$MCPDIR/plugins/p1"
+cat > "$MCPDIR/mcp_config.json" <<'JSON'
+{"mcpServers":{"a":{"command":"node","args":[]},"b":{"command":"npx"},
+               "remote":{"serverUrl":"https://x","authProviderType":"oauth"}}}
+JSON
+check "stdio counted, serverUrl remotes excluded" "0 2" "$(mcp_count "$MCPDIR")" "" ""
+cat > "$MCPDIR/plugins/p1/mcp_config.json" <<'JSON'
+{"mcpServers":{"c":{"command":"node"},"d":{"serverUrl":"https://y"}}}
+JSON
+check "plugin-scoped configs are counted too" "0 3" "$(mcp_count "$MCPDIR")" "" ""
+rm -f "$MCPDIR/mcp_config.json" "$MCPDIR/plugins/p1/mcp_config.json"
+check "no config at all -> rc 1, no false hint" "1 0" "$(mcp_count "$MCPDIR")" "" ""
+printf 'not json' > "$MCPDIR/mcp_config.json"
+check "malformed config is skipped, not fatal" "1 0" "$(mcp_count "$MCPDIR")" "" ""
+
 echo "== agy-media.sh (multimodal delegation) =="
 MEDIA="$ROOT/scripts/agy-media.sh"
 MDIR="$TMP/media"; mkdir -p "$MDIR"


### PR DESCRIPTION
Fixes #37. Reported by @rickberguer with an isolation table that did most of the diagnostic work.

## The bug

`agy`'s stdio MCP children **inherit the wrapper's stdout and outlive `agy`**. A command
substitution only returns when *every* holder of the pipe's write end closes it, so
`OUT="$(agy ...)"` blocks forever.

**The `timeout` guard cannot save us here** — it kills `agy`, but the surviving MCP children
still hold the write end. The protection that exists to bound a hang was structurally
incapable of bounding this one.

Not #6 (native Windows / no ConPTY). Reproduced on macOS with a healthy, authenticated
`agy`; same machine, only `mcp_config.json` changed:

- 16 stdio MCP servers → stdout to file 6.5s ✅ / stdout to pipe **hangs ∞**
- 0 stdio MCP servers → 5.6s either way ✅

Blast radius was everything: `agy-doctor` hung in `agy_guard`, so `/antigravity:setup`
reported a broken or unauthenticated CLI while auth was fine, and `agy-delegate` hung on
every call, taking `agy-job`, `delegate`, `review`, `research` and the delegate subagent
with it.

## The fix

Capture stdout through a temp file, which MCP children inherit harmlessly.

- **`agy-delegate.sh`** — the main invocation, plus the `agy --help` capability probe, which
  had the same hazard and was not in the report. That line has now been wrong twice for two
  unrelated reasons (0.21.1 fixed a SIGPIPE race on it). Cleanup folded into the **existing
  `EXIT` trap**, so it also runs on the timeout and error paths where a trailing `rm -f`
  would not.
- **`doctor.sh`** — `agy_guard` redirects internally and `cat`s at the end, so `cat` is the
  only writer to the caller's pipe and it always exits.
- **`doctor.sh`** — when `agy models` times out, report configured stdio MCP servers. Counts
  **both** sources agy documents (global `mcp_config.json` *and* `plugins/<name>/`), because
  a diagnostic that undercounts fails silently for exactly the person it exists for. Remote
  servers are `serverUrl` on agy 1.1.9, not `url`/`httpUrl`. The text describes agy blocking
  **internally** on a server that never finishes connecting — the mechanism that survives
  this fix — not the pipe one it removes.
- **`agy-job.sh`** — checked, already redirects to files, unchanged.

## Not included

The `--yolo` message originally gained a note that a `permissions.allow`
`write_file(<dir>)` rule grants headless writes. **Removed.** It contradicts `README.md:177`,
`docs/POC-PLAYBOOK.md:77` and SKILL.md, all of which say `--yolo` is *the* durable grant, and
it is the only claim here not backed by our own measurement — confirming it means mutating a
live permissions config. Unrelated to #37, which is urgent enough not to wait behind a docs
question. Asked the reporter to confirm the exact rule so all four can be updated together.

## Verification

Guarded by **shape, not symptom** — a hang is expensive to assert on and the next refactor is
where it returns:

- no command-substitution capture of `agy` in either script
- `doctor`'s `agy_guard` keeps `cat` as the only pipe writer
- a stub reproducing the inherited-stdout hang, asserting the pipe form hangs *and* the file
  form returns

All verified to fail against the unfixed code. **186 tests**, shellcheck clean, `plugin
validate` passes. 0.22.1.

@rickberguer — the stub proves the fd mechanism, not that it's the whole story on a box with
16 servers. Confirmation welcome; not blocking the merge, since a temp file cannot regress
anyone and the plugin is currently unusable for every MCP user.