### PR TITLE
ci: add quorum-review as a second, independent scan (hold until WIF secrets exist)

### DIFF
--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -116,12 +116,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
+    # Every action here is pinned to a commit rather than a tag. A tag can be
+    # moved to point at new code, and this job holds an App installation token
+    # and live Google Cloud credentials — the reason quorum-review's own fork
+    # example gives for pinning applies to every step that runs beside it, not
+    # just to quorum-review itself. Dependabot bumps them.
     steps:
       # The checkout is what the models read beyond the diff. `fetch-depth: 2`
       # keeps the head commit in the clone, which is how the reviewer confirms
       # at run time that it is reading the right tree; without it the tools are
       # withdrawn and the review silently degrades to diff-only.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         id: merge-ref
         continue-on-error: true
         with:
@@ -130,10 +135,11 @@ jobs:
               || github.event.issue.number
               || github.event.inputs.pr }}/merge
           fetch-depth: 2
+          persist-credentials: false
 
       # `/merge` does not exist for a conflicted or closed pull request; `/head`
       # does, and reviewing a conflicted branch is still worth doing.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         if: steps.merge-ref.outcome == 'failure'
         with:
           ref: >-
@@ -143,16 +149,29 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      # Comments arrive as the "Quorum Code Review" App rather than
+      # github-actions[bot]. The token is minted per run and expires with it;
+      # the App holds metadata:read, contents:read, pull_requests:write and no
+      # webhook, so there is no listener and nothing that can push a commit.
+      #
+      # NOTE: `permissions:` above governs GITHUB_TOKEN only. Everything the
+      # reviewer does against the API uses this token instead, so its ceiling is
+      # the App installation's permissions, not the block above. Checkout and the
+      # SARIF upload still use GITHUB_TOKEN.
+      - name: Mint an App installation token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2
+        with:
+          app-id: ${{ vars.QUORUM_APP_ID }}
+          private-key: ${{ secrets.QUORUM_APP_PRIVATE_KEY }}
+
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           project_id: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
 
       - name: Review
-        # Pinned to a commit, not a tag: a tag can be moved to point at new
-        # code, and this job holds a write-scoped token. quorum-review's own
-        # fork example says exactly this; it applies here for the same reason.
         uses: yuting0624/quorum-review@c87fe722861222693f8bed06f3025f20f4a59038  # v1.6.2
         with:
           mode: vertex
@@ -171,6 +190,7 @@ jobs:
           vertex-region: global
           claude-vertex-region: global
           gemini-location: global
+          github-token: ${{ steps.app-token.outputs.token }}
           pr-number: ${{ github.event.inputs.pr }}
           sarif-file: quorum.sarif
           # Advisory while on trial. Make it a required check (`fail-on: critical`)
@@ -182,7 +202,7 @@ jobs:
       - name: Upload to code scanning
         if: always() && hashFiles('quorum.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@a2983b8bed1923f44751c5c43237f479442827b3  # v3
         with:
           sarif_file: quorum.sarif
           category: quorum-review

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -58,15 +58,45 @@ permissions:
   actions: read          # codeql-action needs this to read the run
 
 jobs:
-  review:
-    # Forks are excluded: they get no secrets, so this could only fail on them,
-    # noisily, on every outside contribution. Fork review is label-gated in
-    # claude-review-external.yml and is a different trust model.
-    #
-    # The Bot check prevents a loop — without it the comments this action posts
-    # re-trigger the workflow. `author_association` is a cheap pre-filter, not
-    # the authorisation boundary; the action re-checks real write access itself.
+  # `github.event.pull_request` does NOT exist on `issue_comment`, so the
+  # expression guard below coerces `null != true` to TRUE and lets a fork
+  # through — on the one trigger where a maintainer typing `@quorum /review` on
+  # someone else's PR is an ordinary thing to do. That would check the fork's
+  # merge commit out at the workspace root with live Google Cloud and
+  # write-scoped GitHub credentials, which is exactly what the comment above
+  # claims cannot happen. Resolve it against the API instead of trusting the
+  # payload shape. (Both reviewers on this PR caught this independently; the
+  # upstream example workflow has the same hole.)
+  not-a-fork:
     if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot' &&
+      contains(github.event.comment.body, '@quorum')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          head="$(gh api "repos/$REPO/pulls/$NUM" --jq '.head.repo.full_name')"
+          echo "PR #$NUM head repo: $head"
+          if [ "$head" != "$REPO" ]; then
+            echo "::error::#$NUM is from a fork ($head). Fork review is label-gated in claude-review-external.yml, which isolates the untrusted tree; this workflow does not."
+            exit 1
+          fi
+
+  review:
+    # `not-a-fork` only runs on `issue_comment`; on the other triggers it is
+    # skipped, and `always()` keeps this job reachable while still failing if
+    # the guard actually ran and rejected.
+    needs: [not-a-fork]
+    if: >-
+      always() && needs.not-a-fork.result != 'failure' &&
       github.event.pull_request.head.repo.fork != true &&
       (github.event_name == 'pull_request' ||
        github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -85,6 +85,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Reading a pull request needs this. Omitting it does not merely skip the
+      # check — the job 403s, `review` requires `needs.not-a-fork.result !=
+      # 'failure'`, and the review becomes permanently unreachable on the two
+      # triggers this guard exists to protect. Local verification could not have
+      # caught it: a developer's `gh` session carries far more scope than
+      # GITHUB_TOKEN does here.
+      pull-requests: read
     steps:
       - env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Upload to code scanning
         if: always() && hashFiles('quorum.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@a2983b8bed1923f44751c5c43237f479442827b3  # v3
+        uses: github/codeql-action/upload-sarif@a2983b8bed1923f44751c5c43237f479442827b3  # v3.37.4
         with:
           sarif_file: quorum.sarif
           category: quorum-review

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -191,7 +191,7 @@ jobs:
           project_id: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
 
       - name: Review
-        uses: yuting0624/quorum-review@c87fe722861222693f8bed06f3025f20f4a59038  # v1.6.2
+        uses: yuting0624/quorum-review@a289f4829122c4ffea174cc0b5e949dd87f49f2f  # v1.6.2
         with:
           mode: vertex
           google-cloud-project: ${{ secrets.GOOGLE_CLOUD_PROJECT }}

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -1,0 +1,158 @@
+# Second reviewer: Gemini and Claude read the diff independently, on ONE Google
+# Cloud credential (https://github.com/yuting0624/quorum-review).
+#
+# WHY a second one, next to claude-review.yml. That workflow is a single Opus
+# scan with a prompt full of this repository's own contracts (exit codes,
+# AGY_SIGNAL/AGY_USAGE, version sync, the delegate bash gate). It is good at
+# drift and at things only this repo cares about. What it cannot do is exceed
+# one model's recall: a second opinion only ever sees findings that were already
+# reported, so a bug the scan walked past is never put in front of it. Two
+# independent scans is the only arrangement that raises the ceiling. They are
+# meant to be complementary — if this one starts repeating claude-review, narrow
+# that one's prompt rather than deleting this.
+#
+# NO LONG-LIVED SECRET. The GitHub OIDC token is exchanged for short-lived Google
+# Cloud credentials via Direct Workload Identity Federation, and both Gemini and
+# Claude authenticate off those same ADC. `WIF_PROVIDER` and
+# `GOOGLE_CLOUD_PROJECT` name an identity; they are not credentials.
+#
+# Setup: docs/setup-vertex.md in the quorum-review repository. The step people
+# skip is enabling Claude in Vertex AI Model Garden — miss it and every Claude
+# call returns 404 while the Gemini half keeps working.
+
+name: quorum-review
+
+on:
+  # Deliberately NOT `synchronize` yet. This is on trial as a second reviewer;
+  # reviewing every push doubles the spend before we know it earns it. Add
+  # `synchronize` once it has: `incremental: on` (the default) then reads only
+  # the range since the last review, so a push costs roughly its own size.
+  pull_request:
+    types: [opened, reopened]
+  # `@quorum /review` on a pull request runs it on demand in the meantime.
+  issue_comment:
+    types: [created]
+  # Replying "@quorum wontfix" to a review comment retires that finding.
+  pull_request_review_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to review
+        required: true
+
+# One review at a time per pull request — two runs racing to edit the same
+# summary comment can lose the ledger the other just wrote.
+concurrency:
+  group: >-
+    quorum-review-${{ github.event.pull_request.number
+      || github.event.issue.number
+      || github.event.inputs.pr }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write        # mints the OIDC token; federation fails without it
+  pull-requests: write
+  security-events: write # SARIF upload only
+  actions: read          # codeql-action needs this to read the run
+
+jobs:
+  review:
+    # Forks are excluded: they get no secrets, so this could only fail on them,
+    # noisily, on every outside contribution. Fork review is label-gated in
+    # claude-review-external.yml and is a different trust model.
+    #
+    # The Bot check prevents a loop — without it the comments this action posts
+    # re-trigger the workflow. `author_association` is a cheap pre-filter, not
+    # the authorisation boundary; the action re-checks real write access itself.
+    if: >-
+      github.event.pull_request.head.repo.fork != true &&
+      (github.event_name == 'pull_request' ||
+       github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'pull_request_review_comment' &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(github.event.comment.body, '@quorum') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                 github.event.comment.author_association)) ||
+       (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        (contains(github.event.comment.body, '@quorum /criteria') ||
+         (contains(github.event.comment.body, '@quorum /review') &&
+          github.event.issue.state == 'open')) &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                 github.event.comment.author_association)))
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      # The checkout is what the models read beyond the diff. `fetch-depth: 2`
+      # keeps the head commit in the clone, which is how the reviewer confirms
+      # at run time that it is reading the right tree; without it the tools are
+      # withdrawn and the review silently degrades to diff-only.
+      - uses: actions/checkout@v4
+        id: merge-ref
+        continue-on-error: true
+        with:
+          ref: >-
+            refs/pull/${{ github.event.pull_request.number
+              || github.event.issue.number
+              || github.event.inputs.pr }}/merge
+          fetch-depth: 2
+
+      # `/merge` does not exist for a conflicted or closed pull request; `/head`
+      # does, and reviewing a conflicted branch is still worth doing.
+      - uses: actions/checkout@v4
+        if: steps.merge-ref.outcome == 'failure'
+        with:
+          ref: >-
+            refs/pull/${{ github.event.pull_request.number
+              || github.event.issue.number
+              || github.event.inputs.pr }}/head
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          project_id: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
+
+      - name: Review
+        # Pinned to a commit, not a tag: a tag can be moved to point at new
+        # code, and this job holds a write-scoped token. quorum-review's own
+        # fork example says exactly this; it applies here for the same reason.
+        uses: yuting0624/quorum-review@c87fe722861222693f8bed06f3025f20f4a59038  # v1.6.2
+        with:
+          mode: vertex
+          google-cloud-project: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
+          # A built-in skill, unmodified, on purpose. This is on trial against a
+          # known answer key, and a skill written to match that key would find
+          # it by construction and tell us nothing. If recall turns out to be
+          # poor on shell — the built-ins are tuned for application code, and
+          # this repository is bash — the fix is a repo skill at
+          # `.github/quorum/<name>.md`, measured as a separate arm.
+          skill: code-quality-review
+          # MEASURED, not copied from the docs: `claude-sonnet-5` is served in
+          # `global` and returns FAILED_PRECONDITION ("not servable in region")
+          # in us-central1 for this project. Both models are pinned to the same
+          # region so the code does not fan out across jurisdictions.
+          vertex-region: global
+          claude-vertex-region: global
+          gemini-location: global
+          pr-number: ${{ github.event.inputs.pr }}
+          sarif-file: quorum.sarif
+          # Advisory while on trial. Make it a required check (`fail-on: critical`)
+          # only after its precision on this repository is known.
+
+      # Public repository, so code scanning is free. `continue-on-error` because
+      # a red check for a repository feature nobody bought gets the whole
+      # workflow deleted; the findings are on the PR and in the job summary too.
+      - name: Upload to code scanning
+        if: always() && hashFiles('quorum.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: quorum.sarif
+          category: quorum-review

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -58,21 +58,30 @@ permissions:
   actions: read          # codeql-action needs this to read the run
 
 jobs:
-  # `github.event.pull_request` does NOT exist on `issue_comment`, so the
-  # expression guard below coerces `null != true` to TRUE and lets a fork
-  # through — on the one trigger where a maintainer typing `@quorum /review` on
-  # someone else's PR is an ordinary thing to do. That would check the fork's
-  # merge commit out at the workspace root with live Google Cloud and
-  # write-scoped GitHub credentials, which is exactly what the comment above
-  # claims cannot happen. Resolve it against the API instead of trusting the
-  # payload shape. (Both reviewers on this PR caught this independently; the
-  # upstream example workflow has the same hole.)
+  # `github.event.pull_request` exists on `pull_request` and
+  # `pull_request_review_comment` and NOWHERE ELSE. On `issue_comment` and on
+  # `workflow_dispatch` the expression guard below coerces `null != true` to
+  # TRUE, so a fork sails straight through it — and both are ordinary things for
+  # a maintainer to do: typing `@quorum /review` on someone else's PR, or
+  # dispatching against a PR number by hand. Either would check the fork's merge
+  # commit out at the workspace root with live Google Cloud and write-scoped App
+  # credentials, which is exactly what the comment above claims cannot happen.
+  #
+  # So resolve it against the API on both, rather than trusting the payload
+  # shape. `workflow_dispatch` already needs write access to fire, which makes
+  # it a smaller exposure than the comment path — but "smaller" is not a reason
+  # to guard one and not the other.
+  #
+  # (The issue_comment half was caught independently by both reviewers on this
+  # PR; the dispatch half by the review of the fix. The upstream example
+  # workflow has both.)
   not-a-fork:
     if: >-
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null &&
-      github.event.comment.user.type != 'Bot' &&
-      contains(github.event.comment.body, '@quorum')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       github.event.comment.user.type != 'Bot' &&
+       contains(github.event.comment.body, '@quorum'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -80,9 +89,12 @@ jobs:
       - env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          NUM: ${{ github.event.issue.number }}
+          NUM: ${{ github.event.issue.number || github.event.inputs.pr }}
         run: |
           set -euo pipefail
+          case "${NUM:-}" in
+            ''|*[!0-9]*) echo "::error::no usable pull request number (got '${NUM:-}')"; exit 1 ;;
+          esac
           head="$(gh api "repos/$REPO/pulls/$NUM" --jq '.head.repo.full_name')"
           echo "PR #$NUM head repo: $head"
           if [ "$head" != "$REPO" ]; then


### PR DESCRIPTION
**Draft — do not merge until `WIF_PROVIDER` and `GOOGLE_CLOUD_PROJECT` are set.** The
workflow is inert without them.

## Why a second reviewer

`claude-review.yml` is a single Opus scan carrying this repo's own contracts (exit codes,
`AGY_SIGNAL`/`AGY_USAGE`, version sync, the delegate bash gate). It has earned its place —
on #36 it found three real bugs, two of which were introduced *in that PR*. But one scan
sets a hard ceiling: a second opinion only ever sees findings that were already reported,
so a bug the scan walked past is never put in front of it. Two independent scans is the
only arrangement that raises it.

[quorum-review](https://github.com/yuting0624/quorum-review) runs Gemini and Claude on
**one** Google Cloud credential, has them read the diff without seeing each other's output,
and spends the second opinion only on the findings they disagree about.

They are meant to be **complementary**: quorum for generic correctness, claude-review for
this repo's contracts. If quorum starts repeating claude-review, the fix is to narrow
claude-review's prompt, not to delete either.

## Verified before writing this

- `claude-sonnet-5` and `claude-opus-5` are served on Vertex in `data-agent-bq` — Model
  Garden is enabled, so the step the setup docs call out as the one people miss is done.
- **Region matters and is measured, not copied:** `claude-sonnet-5` returns
  `FAILED_PRECONDITION — not servable in region` in `us-central1`, and answers in `global`.
  Both models are pinned to `global` so the code does not fan out across jurisdictions.
- `gemini-3.6-flash` answers in `global` too.

## Three deliberate choices

- **Built-in skill, unmodified.** This goes on trial against a known answer key — #40 is
  the pre-fix commit of #36 and holds three bugs. A skill written to match that key would
  find it by construction and measure nothing. If recall on *shell* turns out poor (the
  built-ins are tuned for application code; this repo is bash), the fix is a repo skill at
  `.github/quorum/<name>.md`, measured as its own arm.
- **Action pinned to a commit, not a tag.** This job holds a write-scoped token, and a tag
  can be moved. quorum-review's own fork example gives exactly this advice.
- **No `synchronize`, no `fail-on` while on trial** — reviewing every push doubles the
  spend before it has earned it, and a gate needs known precision first. `@quorum /review`
  runs it on demand meanwhile.

## Sequence

1. Set up WIF + the two secrets (commands sent separately)
2. Merge this
3. `workflow_dispatch` it against **#40** and compare against the answer key
4. Decide: keep, add a repo skill, or drop

No plugin code touched.