### PR TITLE
ci: quorum's own comment cancelled the run that posted it

### DIFF
--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -43,11 +43,23 @@ on:
 
 # One review at a time per pull request — two runs racing to edit the same
 # summary comment can lose the ledger the other just wrote.
+#
+# The `-bot` suffix is load-bearing. Posting the summary comment fires
+# `issue_comment`, which lands in this same group, and `cancel-in-progress`
+# then kills the run that posted it. The `review` job's Bot guard does stop the
+# re-review — but concurrency is evaluated BEFORE any job condition, so the
+# cancellation happens regardless. Observed: the backtest run on #40 finished
+# its work and was then marked `cancelled` by its own comment two seconds later.
+# Harmless there because both jobs had already succeeded; not harmless for a
+# trailing step, and a red run for a review that worked is its own problem.
+# Parking bot-triggered runs in a separate group lets them be cancelled freely
+# without touching a real review. (Upstream's example workflow has this too.)
 concurrency:
   group: >-
     quorum-review-${{ github.event.pull_request.number
       || github.event.issue.number
-      || github.event.inputs.pr }}
+      || github.event.inputs.pr
+    }}${{ github.event.comment.user.type == 'Bot' && '-bot' || '' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Found by watching the #40 backtest, not by a reviewer: the run did all its work and was then
marked **cancelled** — by itself.

```
11:00:02  quorum-code-review[bot] posts the summary comment on #40
11:00:04  that fires issue_comment -> same concurrency group -> cancel-in-progress
          -> cancels run 30696711245, the run that just posted it
```

The `review` job's `github.event.comment.user.type != 'Bot'` guard does stop the
*re-review* — but **concurrency is evaluated before any job condition**, so the cancellation
happens anyway. Nothing was lost this time because both jobs had already succeeded; a
trailing step (the SARIF upload) would not be so lucky, and a red run for a review that
worked is misleading on its own.

Bot-triggered runs now get a `-bot` suffix on the concurrency group, so they can be
cancelled freely without touching a real review. Simulated GitHub's `||` semantics across
all four triggers — the two sets are disjoint:

```
pull_request #40                   -> quorum-review-40
workflow_dispatch pr=40            -> quorum-review-40
issue_comment by human on #40      -> quorum-review-40
issue_comment by the bot on #40    -> quorum-review-40-bot
review_comment by the bot          -> quorum-review-40-bot
```

Upstream's `examples/review-vertex.yml` has the same shape; I'll report it along with the
fork-guard holes.