### PR TITLE
docs: cross-link quorum-review as the peer arrangement of the same two models

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ In Claude Code:
 
 ---
 
+## 🗳️ The same two models, arranged differently
+
+This plugin is one shape of Claude and Gemini working together: **conductor and executor** — judgement on one side, throughput on the other, one workflow.
+
+[**quorum-review**](https://github.com/yuting0624/quorum-review) is the other shape: the two as **peers**. Both read the same pull request independently, neither sees the other's output, and where they agree independently *that is the result* — only the disagreements are worth a second opinion. Both run on **one** Google Cloud credential, so no vendor API keys live in the repository. Same author as this plugin.
+
+**This repo is its client zero.** It runs on every pull request opened here, alongside a Claude review — including the ones that change this plugin. Keeping the habit of not quoting numbers we haven't measured, here is what that has actually been worth:
+
+- On a fixture holding three known bugs it found **two, with no false positives**, and reached the correct root cause on one that the single-model review took two rounds to get right.
+- Reviewing this repo's own CI, both of its models **independently** caught a fork-guard hole in the review workflow itself — one that would have put an outside contributor's code on the runner next to live credentials.
+- It has also produced a confident **false positive that both models agreed on** — the code disproving it lived outside the checkout either model could read.
+
+That last one is the useful lesson, and it cuts against the obvious pitch: two independent scans insure you against *one model's* blind spot. They do not insure you against a gap in what you handed **both** of them.
+
+---
+
 <details>
 <summary><b>🛠️ Direct script usage &amp; tiers</b></summary>
 
@@ -214,7 +230,9 @@ bash tests/run-tests.sh
 
 Early-stage and MIT — issues, PRs, and ⭐ all welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) and the [`good first issue`](https://github.com/yuting0624/antigravity-for-claude-code/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) list.
 
-**Automated review:** PRs get a Claude code review in CI on top of the usual tests/shellcheck. For PRs from forks it runs **only after a maintainer adds the `claude-review` label** — external code is never executed by the reviewer, it's checked out read-only into a subdirectory and only read.
+**Automated review:** PRs get two reviews in CI on top of the usual tests/shellcheck — a Claude review carrying this repo's own contracts, and [quorum-review](https://github.com/yuting0624/quorum-review) — see the section above.
+
+**From a fork:** quorum doesn't run at all. The Claude review runs only once a maintainer **with write access** applies the `claude-review` label — the label alone isn't authorisation, since triage collaborators can apply labels too — and it re-runs on every later push, so an approved review can't go stale behind new commits. Your code is never executed by the reviewer: it's checked out read-only into a subdirectory and only read.
 
 ---
 


### PR DESCRIPTION
Adds a short section positioning [quorum-review](https://github.com/yuting0624/quorum-review) as
**the other shape of the same idea** — this plugin runs Claude and Gemini as conductor and
executor; quorum runs them as peers on the same diff — and says that this repo is its client
zero. Same author, disclosed.

## Why it's written the way it is

This README's whole credibility rests on not overselling: *"no flat 8×/46%"*, *"numbers are
estimates"*, *"set your real rates before quoting any figure"*. A promo block would clash with
that, so the section carries **what quorum got wrong** as well as what it caught:

- three-bug fixture → found two, no false positives, and reached the correct root cause on one
  the single-model review took two rounds to get right
- caught a fork-guard hole in this repo's own CI, both models independently
- **produced a confident false positive both models agreed on** — the disproving code lived
  outside the checkout either could read

That last point is the section's actual conclusion: two independent scans insure you against
*one model's* blind spot, not against a gap in what you handed **both**.

## Placement

After the slash-command table, before the collapsible advanced material — so it doesn't
interrupt why → what → measured → install, but isn't buried under `<details>` either.

## Two claims trimmed while writing it

Checked against the workflows rather than written from memory:

- "reviews every pull request" → **"runs on every pull request opened here"**. quorum triggers
  on `opened`/`reopened`; `synchronize` is deliberately off while it's on trial.
- "would have let an outside contributor's code reach live credentials" → the hole was
  reachable by a **maintainer doing an ordinary thing** (`@quorum /review` on a fork PR), not by
  an outside contributor self-triggering. Different severity, worth stating accurately.

## Also fixed

The Contributing note still described the `claude-review` label as sufficient authorisation.
That stopped being true in #38, which added the write-access check on whoever applied it and
re-review on every later push. Updated.

Used a direct link rather than an intra-page anchor — GitHub's slug for an emoji heading isn't
what it looks like, and I'd have shipped a dead one.

Both external links verified `200`. No plugin code touched; 188 tests, validate passes.