### PR TITLE
fix: --yolo is not the only headless write grant (8 places said it was)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.22.2
+- **Correction: `--yolo` is not the only way to grant a headless write, and we said it was
+  in eight places.** A `write_file(<dir>)` entry under `permissions.allow` in
+  `~/.gemini/antigravity-cli/settings.json` grants writes **recursively beneath `<dir>`**
+  with no flag at all. Confirmed on **agy 1.1.9** by @rickberguer with a controlled A/B
+  ([#37](https://github.com/yuting0624/antigravity-for-claude-code/issues/37)): a covered
+  target wrote, an uncovered one returned `PERMISSION_DENIED`, the rule the only variable.
+  agy's own soft-deny message names the rule and offers `--yolo` as the *alternative* — the
+  CLI had been saying this for a while and we had not.
+  This matters beyond accuracy: we were recommending `--dangerously-skip-permissions`, which
+  approves **every** tool, where a grant scoped to one directory subtree would do. `--yolo`
+  is still what you need when no rule covers the target, and for web / Vertex AI Search /
+  terminal / `define_subagent` — a `write_file` rule covers writes only.
+  **The eighth place was the wrapper itself.** The write-task nudge fired immediately before
+  a write that then succeeded, telling the user headless agy "will NOT write to your
+  workspace without it". Corrected, along with the exit-15 message — which is exactly where
+  someone lands after a denial and so is the best place to name the narrower fix. Also
+  README, SKILL.md, POC-PLAYBOOK.md, TROUBLESHOOTING.md (both the fix list and the exit-code
+  table), `commands/delegate.md` and the delegate subagent's own instructions.
+  Scoped to what was actually measured: not verified below agy 1.1.9, and a glob form
+  (`write_file(/path/**)`) was reported *not* to match. The wrapper cannot see
+  `settings.json`, so the nudge stays a warning rather than a check — it just no longer
+  asserts something false.
+- Tests assert the wrapper offers the `permissions.allow` route on both the warning and the
+  exit-15 path, and that it no longer claims `--yolo` is required. The warning assertion now
+  matches a stable substring — that string has been reworded twice and an exact-phrase test
+  breaks on prose edits rather than on behaviour.
+- **Confirmed: the #37 hang fix clears the reporting environment.** 16 MCP servers (9 stdio,
+  7 remote): `agy-doctor` 3.5s all-pass and a delegation round-trip in 6.7s, both previously
+  hanging. The remote servers are spelled `serverUrl`, matching what 0.22.1's detector
+  assumes.
+
 ## 0.22.1
 - **Fix: every wrapper hung forever when stdio MCP servers were configured.** Reported by
   @rickberguer (#37) on macOS with a healthy, authenticated agy. `agy`'s stdio MCP children

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ scripts/agy-delegate.sh --tier pro --dir ./src "List every TODO with file:line"
 # bulk read -> digest-only reply (the biggest cost lever; wrapper warns on dump-sized replies)
 scripts/agy-delegate.sh --digest --dir . "Map the auth flow end to end"
 
-# write task: --yolo is the reliable headless write grant (run on a branch; verify git status)
+# write task: needs a grant — a permissions.allow write_file(<dir>) rule, or --yolo (run on a branch)
 scripts/agy-delegate.sh --yolo --dir ./app "Implement X per SPEC.md"
 
 # live web / Google search (tools need --yolo in headless mode)
@@ -190,7 +190,26 @@ Delegation doesn't save money by itself — these do (also in the skill):
 - `-p`/`--print` **takes the prompt as its value** and must come last — the wrapper handles this.
 - `--print` drops stdout on a non-TTY unless stdin is detached (handled via `< /dev/null`). **Structured output arrived in agy 1.1.8** (`--output-format json`): the wrapper now uses it internally on ≥1.1.8 to classify failures from the structured error and to report the executor's real token usage (incl. `cache_read`) as an `AGY_USAGE` line on stderr — stdout is unchanged. Older agy falls back to plain text (toggle with the `structured_output` option). **If you're measuring, set `AGY_USAGE_LOG=/path`** (or the `usage_log` option): stderr is easily lost — `2>&1 | tail -N`, the natural way to keep Claude's context lean, keeps the digest and drops the usage line.
 - **The executor's trajectory is auditable.** Every agy run writes a step-by-step `transcript.jsonl`, and the `conversationId` in `AGY_USAGE` joins it to the cost 1:1. `agy-trace --audit <id>` (or `--audit --last`) shows step-type counts and every non-zero exit — a delegation can report SUCCESS while commands inside it failed. The command **strings** are recorded nowhere, so to attribute a filesystem change you must diff the tree.
-- **Writes need `--yolo`:** headless agy's no-permission behavior keeps shifting (describe-only pre-1.1.0 · scratch-divert 1.1.0–1.1.2 · soft-deny 1.1.3+), but every version leaves **your workspace untouched while the run still "succeeds"** ([issue #10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)). The durable grant is **`--yolo`** (`--dangerously-skip-permissions`) — `--mode accept-edits` only wrote headless on 1.1.0–1.1.2. Run write tasks on a branch and verify with `git status`; the wrapper maps a 1.1.3 soft-deny to exit `15`. Long write tasks can exceed the ~2-min sync Bash limit → use a background job.
+- **Two write grants, and the narrow one is not `--yolo`.** Headless agy's
+  no-permission behavior has shifted every few releases (describe-only pre-1.1.0 ·
+  scratch-divert 1.1.0–1.1.2 · soft-deny 1.1.3+), and in every version an ungranted write
+  leaves **your workspace untouched while the run still "succeeds"**
+  ([#10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)). Two things
+  grant it:
+  
+  - **`permissions.allow` in `~/.gemini/antigravity-cli/settings.json`** — a
+    `write_file(<dir>)` entry allows writes **recursively beneath `<dir>`** and needs no
+    flag. This is the narrower grant and usually the right one.
+  - **`--yolo`** (`--dangerously-skip-permissions`) — auto-approves **all** tools, not just
+    writes. Needed when no rule covers the target, and for web / Vertex AI Search / terminal
+    tools.
+  
+  Confirmed on **agy 1.1.9** by a controlled A/B ([#37](https://github.com/yuting0624/antigravity-for-claude-code/issues/37)):
+  a covered target wrote with no flag; an uncovered one came back `PERMISSION_DENIED` with
+  the rule as the only variable. agy's own denial text names the rule and offers `--yolo` as
+  the alternative. Not verified on other versions, and a glob form (`write_file(/path/**)`)
+  was reported *not* to match. Either way: run write tasks on a branch and verify with
+  `git status`; the wrapper maps a soft-deny to exit `15`.
 - **Native Windows (no ConPTY):** headless `agy -p` / `agy models` can hard-hang with a 0-byte log when stdio is redirected ([issue #6](https://github.com/yuting0624/antigravity-for-claude-code/issues/6)). The wrapper wraps agy in a wall-clock `timeout`/`gtimeout` guard so it returns a structured TIMEOUT (exit 12) instead of hanging; `doctor` reports the likely hang instead of a misleading "not authenticated". Without `timeout` on PATH there's no safety net — use **WSL/macOS/Linux** for headless delegation.
 - **WSL:** running agy with `--add-dir` on a Windows mount (`/mnt/c/...`) is very slow — agy reads the workspace over a 9p bridge, so even trivial calls can take 20s+. Keep the repo on the WSL Linux filesystem (`~`). The wrapper and `doctor` warn about this.
 

--- a/agents/antigravity-delegate.md
+++ b/agents/antigravity-delegate.md
@@ -83,9 +83,13 @@ Options: `--tier flash|flash-lo|pro` · `--dir <repo-root>` (so agy reads
 
 ## Modes
 
-- **Write / build** (scaffold, implement, generate tests, migrate): agentic mode,
-  pass `--yolo`; for write tasks tell the caller it should run on a dedicated
-  branch/worktree and review the diff before merging.
+- **Write / build** (scaffold, implement, generate tests, migrate): agentic mode, and the
+  write needs a grant. Pass `--yolo` unless the user has a `permissions.allow`
+  `write_file(<dir>)` rule covering the target in `~/.gemini/antigravity-cli/settings.json`
+  — that grants the write recursively beneath `<dir>` with no flag, and is narrower than
+  `--yolo`, which approves every tool. You cannot see that file, so `--yolo` stays the
+  default; if a run comes back exit `15`, the allow-rule is the smaller fix. Either way tell
+  the caller to run on a dedicated branch/worktree and review the diff before merging.
 - **Read-only** (analysis, first-pass review, search): no `--yolo` needed unless
   the task uses tools (web / Vertex AI Search need `--yolo`). Ask agy to return
   findings + `file:line` only.

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -11,8 +11,11 @@ Task: $ARGUMENTS
 Do this:
 1. Pick a tier (`flash` default; `pro` for hard reasoning). If the task needs the repo,
    add `--dir <repo-root>` so agy reads the real files (don't paste them into context).
-   **If the task WRITES files or uses tools** (web / Vertex AI Search / terminal), pass
-   **`--yolo`** — the reliable headless write/tool grant across agy versions. Without it,
+   **If the task WRITES files or uses tools** (web / Vertex AI Search / terminal), it needs
+   a grant. For a plain file write the narrower one is a `write_file(<dir>)` entry under
+   `permissions.allow` in `~/.gemini/antigravity-cli/settings.json` (recursive beneath
+   `<dir>`, no flag needed). Otherwise pass **`--yolo`**, which auto-approves all tools and
+   is what web / Vertex AI Search / terminal need. Without a grant,
    headless agy leaves your workspace untouched while still reporting success (it
    describes / scratch-diverts / soft-denies depending on version; issue #10). `--mode
    accept-edits` is NOT a dependable substitute — it only wrote headless on agy 1.1.0–1.1.2

--- a/docs/POC-PLAYBOOK.md
+++ b/docs/POC-PLAYBOOK.md
@@ -71,13 +71,26 @@ After each lever: rerun the task → rerun the gate → keep only if quality hel
 
 ## 4. Write-task hygiene (the traps, pre-paid)
 
-- **Writes / tool use need `--yolo`.** Headless agy's no-permission behavior has changed
-  every few releases (describe-only → scratch-divert → soft-deny on 1.1.3), but in every
-  version **the workspace is left untouched while the run still "succeeds."** The one
-  durable grant is `--yolo` (`--dangerously-skip-permissions`), on a dedicated branch, with
-  `--sandbox`. (`--mode accept-edits` only wrote headless on agy 1.1.0–1.1.2 and is
-  soft-denied on 1.1.3 — don't rely on it.) **Always verify with `git status`.** If the
-  wrapper returns exit `15`, that's a soft-denied write — add `--yolo`.
+- **Two write grants, and the narrow one is not `--yolo`.** Headless agy's
+  no-permission behavior has shifted every few releases (describe-only pre-1.1.0 ·
+  scratch-divert 1.1.0–1.1.2 · soft-deny 1.1.3+), and in every version an ungranted write
+  leaves **your workspace untouched while the run still "succeeds"**
+  ([#10](https://github.com/yuting0624/antigravity-for-claude-code/issues/10)). Two things
+  grant it:
+  
+  - **`permissions.allow` in `~/.gemini/antigravity-cli/settings.json`** — a
+    `write_file(<dir>)` entry allows writes **recursively beneath `<dir>`** and needs no
+    flag. This is the narrower grant and usually the right one.
+  - **`--yolo`** (`--dangerously-skip-permissions`) — auto-approves **all** tools, not just
+    writes. Needed when no rule covers the target, and for web / Vertex AI Search / terminal
+    tools.
+  
+  Confirmed on **agy 1.1.9** by a controlled A/B ([#37](https://github.com/yuting0624/antigravity-for-claude-code/issues/37)):
+  a covered target wrote with no flag; an uncovered one came back `PERMISSION_DENIED` with
+  the rule as the only variable. agy's own denial text names the rule and offers `--yolo` as
+  the alternative. Not verified on other versions, and a glob form (`write_file(/path/**)`)
+  was reported *not* to match. Either way: run write tasks on a branch and verify with
+  `git status`; the wrapper maps a soft-deny to exit `15`.
 - **One shared [`AGENTS.md`](https://github.com/yuting0624/antigravity-for-claude-code#-what-it-does)
   at the repo root** — the biggest first-pass-success factor, which means fewer retries,
   which means fewer conductor turns.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -104,8 +104,15 @@ run still "succeeds"** ([#10](https://github.com/yuting0624/antigravity-for-clau
 - 1.1.3+: **soft-denies** the write and prints a stderr notice naming the allow-rule
 
 **Fix:**
-- **Pass `--yolo`** (`--dangerously-skip-permissions`) — the one write/tool grant that
-  works headless across all agy versions. (`--mode accept-edits` only wrote headless on
+- **For a file write, add an allow-rule — the narrower fix.** In
+  `~/.gemini/antigravity-cli/settings.json`, under `permissions.allow`, add
+  `write_file(<dir>)`. It matches **recursively beneath `<dir>`** and needs no flag.
+  This is the rule agy's own soft-deny message is naming. Confirmed on agy 1.1.9 by a
+  controlled A/B ([#37](https://github.com/yuting0624/antigravity-for-claude-code/issues/37));
+  a glob form (`write_file(/path/**)`) was reported *not* to match.
+- **Or pass `--yolo`** (`--dangerously-skip-permissions`) — works across all agy versions,
+  but auto-approves **all** tools, not just the write. Required anyway for web / Vertex AI
+  Search / terminal when no rule covers them. (`--mode accept-edits` only wrote headless on
   1.1.0–1.1.2 and is soft-denied on 1.1.3 — don't rely on it.)
 - Claude Code may prompt for (or in auto-mode, block) `--dangerously-skip-permissions` —
   approve it, or pre-allow `Bash(agy-delegate*)` in your permission settings.
@@ -135,7 +142,7 @@ On classifiable failures the wrapper prints a machine-readable line to stderr:
 | 12 | timeout (agy's own, or the wall-clock guard) | raise `--timeout`, narrow the task; on Windows see the hang section above |
 | 13 | agy not on PATH | install the Antigravity CLI |
 | 14 | model unavailable | the `--model` / `tier_*` / `default_model` name isn't in `agy models` (agy ≥ 1.1.2 hard-fails instead of silently downgrading) — run `agy models` and fix the name |
-| 15 | permission denied | agy ≥ 1.1.3 soft-denied a tool needing permission in headless mode (e.g. a file write) — pass `--yolo` and run on a branch |
+| 15 | permission denied | agy ≥ 1.1.3 soft-denied a tool needing permission in headless mode (e.g. a file write) — add a `permissions.allow` rule covering the target, or pass `--yolo`; run on a branch |
 
 ---
 

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -231,17 +231,29 @@ if on_wsl; then
   done
 fi
 
-# Heads-up: a likely write task without write permission. Headless agy's write behavior
-# has shifted across versions (describe-only pre-1.1.0; scratch-divert 1.1.0-1.1.2;
-# soft-deny with a stderr notice on 1.1.3) — but the one durable grant is --yolo. Without
-# it, YOUR WORKSPACE IS UNTOUCHED (issue #10). (--mode accept-edits worked headless only on
-# 1.1.0-1.1.2 and is soft-denied on 1.1.3, so it no longer suppresses this warning.)
+# Heads-up: a likely write task with no visible write grant. Headless agy's write
+# behavior has shifted across versions (describe-only pre-1.1.0; scratch-divert
+# 1.1.0-1.1.2; soft-deny with a stderr notice on 1.1.3), and without a grant YOUR
+# WORKSPACE IS UNTOUCHED while the run still "succeeds" (issue #10).
+#
+# There are TWO grants, and this used to claim there was one. A `write_file(<dir>)`
+# rule under `permissions.allow` in ~/.gemini/antigravity-cli/settings.json grants
+# headless writes beneath that path with no --yolo at all — confirmed on agy 1.1.9 by
+# a controlled A/B (#37): covered target wrote, uncovered target came back
+# PERMISSION_DENIED with the rule as the only variable. The match is a RECURSIVE
+# PREFIX, not one directory. agy's own denial text names the rule and offers --yolo as
+# the alternative, so the CLI has been saying this for a while and we were not.
+#
+# We cannot see settings.json from here (it is not ours, and --dir is not where it
+# lives), so this stays a warning rather than a check — but it must not assert that
+# --yolo is required. It fired immediately before a write that then succeeded.
+# (--mode accept-edits worked headless only on 1.1.0-1.1.2 and is soft-denied on 1.1.3.)
 # Best-effort heuristic; warn only. --print-command (dry run) is exempt.
 if [ "$YOLO" -eq 0 ] && [ "$PRINT_CMD" -ne 1 ]; then
   shopt -s nocasematch
   case "$PROMPT" in
     *implement*|*scaffold*|*migrate*|*refactor*|*"write the file"*|*"create the file"*|*"edit the file"*)
-      echo "agy-delegate: note: this looks like a write task but --yolo is not set — headless agy will NOT write to your workspace without it (it describes / scratch-diverts / soft-denies depending on version, while the run still 'succeeds'; issue #10). Add --yolo and run on a dedicated branch, then verify with git status." >&2 ;;
+      echo "agy-delegate: note: this looks like a write task and --yolo is not set. Headless agy will NOT touch your workspace without a write grant (it describes / scratch-diverts / soft-denies depending on version, while the run still 'succeeds'; issue #10). Two grants work: a permissions.allow rule matching the target — write_file(<dir>), a recursive prefix, in ~/.gemini/antigravity-cli/settings.json — which is the narrower one and needs no flag; or --yolo, which auto-approves ALL tools. If a rule already covers your target, ignore this. Otherwise add one, or pass --yolo on a dedicated branch, and verify with git status." >&2 ;;
   esac
   shopt -u nocasematch
 fi
@@ -482,8 +494,8 @@ if [ -z "${OUT//[$' \t\n\r']/}" ]; then
     *"auto-denied"*|*"permissions.allow"*|*"permission that headless"*|*"dangerously-skip-permissions"*)
       shopt -u nocasematch
       [ -s "$ERR" ] && cat "$ERR" >&2
-      echo "agy-delegate: agy soft-denied a tool that needs permission (headless can't prompt) — no work was done. For file writes add --yolo (run on a branch); tool use (web/Vertex/terminal) also needs --yolo. (agy >= 1.1.3)" >&2
-      signal PERMISSION_DENIED "agy soft-denied a permissioned tool in headless — pass --yolo"; exit 15 ;;
+      echo "agy-delegate: agy soft-denied a tool that needs permission (headless can't prompt) — no work was done. For a FILE WRITE, the narrower fix is a permissions.allow rule covering the target in ~/.gemini/antigravity-cli/settings.json — write_file(<dir>) matches recursively beneath <dir> — which needs no flag; --yolo also works but auto-approves ALL tools. Other tools (web / Vertex AI Search / terminal) need --yolo unless a rule covers them. agy's own message above names the specific permission it wanted. (agy >= 1.1.3)" >&2
+      signal PERMISSION_DENIED "agy soft-denied a permissioned tool in headless — add a permissions.allow rule or pass --yolo"; exit 15 ;;
   esac
   shopt -u nocasematch
   echo "agy-delegate: agy returned empty output (model='$MODEL')" >&2

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.22.1
+version: 0.22.2
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -78,10 +78,13 @@ the cross-model verification value (Claude executing Claude loses both).
 agy-delegate [options] "the task prompt"
 ```
 Options: `--tier flash|flash-lo|pro` · `--dir <path>` (workspace, repeatable) ·
-`--timeout 10m` · `--yolo` (auto-approve ALL tools — the reliable headless grant for **any
-file write or tool use**; run write tasks on a branch) · `--mode accept-edits|plan`
+`--timeout 10m` · `--yolo` (auto-approve **ALL** tools — the blunt grant; needed for web /
+Vertex AI Search / terminal, and for writes not covered by a `permissions.allow` rule. For a
+file write the narrower grant is usually a `write_file(<dir>)` entry in
+`~/.gemini/antigravity-cli/settings.json`, which needs no flag — see below. Run write tasks
+on a branch) · `--mode accept-edits|plan`
 (agy execution mode: `accept-edits` auto-applied file edits headless on 1.1.0–1.1.2 but is
-**soft-denied on 1.1.3** — no longer a dependable headless write grant, use `--yolo`;
+**soft-denied on 1.1.3** — no longer a dependable headless write grant;
 `plan` = strategize only) · `--sandbox` ·
 `--digest` (append a digest-only output contract — use it for any
 bulk read/analysis; the wrapper also warns on stderr when a reply comes back dump-sized,
@@ -191,12 +194,18 @@ If wrong: retry on `--tier pro`, sharpen the spec, or do that piece yourself.
 
 Read-only work (search, review, analysis) is low-risk. **When agy writes files or runs
 commands** (`--yolo` grants write + terminal):
-- **Write tasks MUST pass `--yolo`.** Headless agy's no-permission behavior has shifted
+- **Write tasks need a grant — and it does not have to be `--yolo`.** Headless agy's no-permission behavior has shifted
   every few releases — describe-only (pre-1.1.0), scratch-divert (1.1.0–1.1.2), soft-deny
   with a stderr notice (1.1.3) — but in every version **your workspace stays untouched
-  while the run still "succeeds"** (issue #10). The one durable write grant is `--yolo`
-  (`--dangerously-skip-permissions`). (`--mode accept-edits` only wrote headless on
-  1.1.0–1.1.2 and is soft-denied on 1.1.3 — don't rely on it for writes.) Claude Code may
+  while the run still "succeeds"** (issue #10). **Two things grant a write, and `--yolo` is
+  the blunt one.** A `write_file(<dir>)` entry under `permissions.allow` in
+  `~/.gemini/antigravity-cli/settings.json` allows writes **recursively beneath `<dir>`**
+  with no flag at all — confirmed on agy 1.1.9 by a controlled A/B (#37): covered target
+  wrote, uncovered target returned `PERMISSION_DENIED`, rule the only variable. agy's own
+  denial text names the rule and offers `--yolo` as the *alternative*. `--yolo` auto-approves
+  **all** tools and is what you need when no rule covers the target, or for web / Vertex AI
+  Search / terminal. Not verified below 1.1.9; a glob form (`write_file(/path/**)`) was
+  reported not to match. Run write tasks on a branch and verify with `git status`.
   prompt for or block `--dangerously-skip-permissions` — approve it or pre-allow
   `Bash(agy-delegate*)`. Always verify files actually changed **in the workspace** with
   `git status` (the wrapper maps a 1.1.3 soft-deny to exit `15` so you're not left guessing).
@@ -379,8 +388,9 @@ agy-delegate --dir . --yolo --digest --timeout 10m \
 Verified behaviors (1.0.12 → 1.1.5):
 - **Pass `--yolo`.** On 1.1.3+ the subagent tools need permission that headless mode
   can't prompt for, so without `--yolo` the spawn is soft-denied (wrapper exit 15).
-  (On 1.0.x spawning was ungated, but `--yolo` is the durable choice; writes/web tools
-  *inside* the subagents' work always need it.)
+  (On 1.0.x spawning was ungated, but `--yolo` is the durable choice here: a
+  `permissions.allow` `write_file(...)` rule covers file writes only, not
+  `define_subagent`/`invoke_subagent`, and not web / Vertex AI Search.)
 - Each spawn's tool result includes a `logAbsoluteUri` → a **readable step-by-step
   `transcript.jsonl`** under `~/.gemini/antigravity-cli/brain/<conversationId>/` —
   *better* trajectory visibility than a plain delegation. Location unchanged across

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -344,9 +344,11 @@ check "--print-command shows the tier model" 0 "$rc" "Pro" "$out"
 out=$(PATH="/usr/bin:/bin" "$DELEGATE" --print-command "hi" 2>/dev/null); rc=$?
 check "--print-command works without agy on PATH" 0 "$rc" "--print-timeout" "$out"
 
-# write-task without --yolo -> warn (workspace untouched; issue #10). The one durable
-# grant is --yolo; --mode accept-edits stopped granting headless writes on agy 1.1.3.
-WARN='NOT write to your workspace'
+# write-task without --yolo -> warn (workspace untouched; issue #10).
+# --mode accept-edits stopped granting headless writes on agy 1.1.3, so it still warns.
+# Match the stable part of the sentence, not the whole thing: this string has been
+# reworded twice now, and an exact-phrase assertion just breaks on prose edits.
+WARN='write grant'
 out=$(STUB_MODE=args "$DELEGATE" "implement the parser module" 2>&1); rc=$?
 check "write prompt w/o --yolo -> warns" 0 "$rc" "$WARN" "$out"
 out=$(STUB_MODE=args "$DELEGATE" --yolo "implement the parser module" 2>&1); rc=$?
@@ -358,6 +360,17 @@ else echo "FAIL: no warning with --mode accept-edits (should warn since 1.1.3)";
 out=$(STUB_MODE=args "$DELEGATE" "summarize the changelog in 3 bullets" 2>&1); rc=$?
 if printf '%s' "$out" | grep -qF "$WARN"; then echo "FAIL: warned for a non-write prompt"; FAIL=$((FAIL+1));
 else echo "ok: no write-warning for a read/summary prompt"; PASS=$((PASS+1)); fi
+# The warning must NOT claim --yolo is the only way in. Confirmed on agy 1.1.9 by a
+# controlled A/B (#37): a permissions.allow write_file(<dir>) rule grants headless writes
+# with no flag, and this warning fired immediately before one that succeeded.
+out=$(STUB_MODE=args "$DELEGATE" "implement the parser module" 2>&1)
+check "write warning names the permissions.allow route" 0 0 "permissions.allow" "$out"
+if printf '%s' "$out" | grep -q 'NOT write to your workspace without it'; then
+  echo "FAIL: warning still asserts --yolo is required for a write"; FAIL=$((FAIL+1));
+else echo "ok: warning no longer claims --yolo is the only write grant"; PASS=$((PASS+1)); fi
+# Same correction on the exit-15 path — where someone lands after being denied.
+out=$(STUB_MODE=softdeny "$DELEGATE" "implement it" 2>&1); rc=$?
+check "exit-15 message offers the narrower grant first" 15 "$rc" "permissions.allow" "$out"
 
 # --mode passthrough (agy >= 1.1.0): accept-edits reaches agy; invalid mode errors early
 out=$(STUB_MODE=args "$DELEGATE" --mode accept-edits "hi" 2>/dev/null); rc=$?


### PR DESCRIPTION
@rickberguer settled the open question from #37 with a **controlled A/B** on agy 1.1.9 —
better evidence than we could produce, since it needs a live permissions config:

| | rule covering target | result |
|---|---|---|
| `/private/tmp/claude-501/.../allow-proof.txt` | `write_file(/private/tmp/claude-501)` | **wrote, no `--yolo`** |
| `/private/tmp/agy-control-nortule/control.txt` | none | `PERMISSION_DENIED`, no file |

The rule is the only variable, and the match is a **recursive prefix**, not one directory.
agy's own soft-deny message names the rule and presents `--yolo` as the *alternative* — the
CLI has been saying this for a while and we haven't.

## Why this is more than an accuracy fix

We were telling people to reach for `--dangerously-skip-permissions`, which approves **every
tool**, in cases where a grant scoped to a single directory subtree would do. The docs were
recommending the bigger hammer.

## The eighth place was the wrapper itself

The reporter caught this, and it's the one that matters most: on the run that **succeeded
without `--yolo`**, our own nudge had just printed

> headless agy will **NOT** write to your workspace without it

Corrected there, and on the **exit-15 message** — where someone lands after being denied, so
it's the best possible place to name the narrower fix. Plus `README.md`, `SKILL.md`,
`docs/POC-PLAYBOOK.md`, `docs/TROUBLESHOOTING.md` (both the fix list and the exit-code
table), `commands/delegate.md`, and the delegate subagent's instructions.

## Kept where `--yolo` is still right

A `write_file` rule covers **writes only**. `--yolo` is still needed for web / Vertex AI
Search / terminal, for `define_subagent`/`invoke_subagent`, and for any write no rule covers.
The fan-out recipe in SKILL.md keeps it for exactly that reason, now stated explicitly.

## Scoped to what was measured

Not verified below agy 1.1.9. A glob form (`write_file(/path/**)`) was reported *not* to
match, and is labelled anecdotal. The wrapper can't read `settings.json` — it isn't ours and
isn't under `--dir` — so the nudge stays a **warning rather than a check**; it just no longer
asserts something false.

## Also confirmed in the same reply

The #37 hang fix clears the reporting environment: 16 MCP servers (9 stdio, 7 remote),
`agy-doctor` 3.5s all-pass and a delegation round-trip in 6.7s, both previously hanging. The
remote servers are spelled `serverUrl` — matching what 0.22.1's detector assumes.

191 tests, shellcheck clean, validate passes. 0.22.2.