### PR TITLE
ci: adopt upstream's cancel-in-progress expression over our -bot group

### DIFF
--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -44,23 +44,22 @@ on:
 # One review at a time per pull request — two runs racing to edit the same
 # summary comment can lose the ledger the other just wrote.
 #
-# The `-bot` suffix is load-bearing. Posting the summary comment fires
-# `issue_comment`, which lands in this same group, and `cancel-in-progress`
-# then kills the run that posted it. The `review` job's Bot guard does stop the
-# re-review — but concurrency is evaluated BEFORE any job condition, so the
-# cancellation happens regardless. Observed: the backtest run on #40 finished
-# its work and was then marked `cancelled` by its own comment two seconds later.
-# Harmless there because both jobs had already succeeded; not harmless for a
-# trailing step, and a red run for a review that worked is its own problem.
-# Parking bot-triggered runs in a separate group lets them be cancelled freely
-# without touching a real review. (Upstream's example workflow has this too.)
+# `cancel-in-progress` has to be an EXPRESSION, not `true`. Concurrency is
+# evaluated before any job condition, so a run that will be skipped still enters
+# the group and still cancels whatever is running — and posting the summary
+# comment fires `issue_comment`, so the review cancelled itself seconds after
+# finishing. The Bot check in `if:` stops the loop; it cannot stop the
+# cancellation.
+#
+# This is upstream's shape, adopted in place of the `-bot` group suffix we had.
+# Theirs is better: the bot run stays in the same group, so a real run can still
+# cancel it — a separate group meant a stale bot run just sat there instead.
 concurrency:
   group: >-
     quorum-review-${{ github.event.pull_request.number
       || github.event.issue.number
-      || github.event.inputs.pr
-    }}${{ github.event.comment.user.type == 'Bot' && '-bot' || '' }}
-  cancel-in-progress: true
+      || github.event.inputs.pr }}
+  cancel-in-progress: ${{ github.event.comment.user.type != 'Bot' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Upstream took the self-cancellation report ([quorum#15](https://github.com/yuting0624/quorum-review/issues/15)) and fixed it **better than the shape I suggested**.

Instead of suffixing the concurrency group for bot-triggered runs, `cancel-in-progress` is itself an expression:

```yaml
cancel-in-progress: ${{ github.event.comment.user.type != 'Bot' }}
```

Same outcome for the bug — the run that posts the summary comment no longer kills the run that posted it — but the bot run **stays in the real group**, so a genuine run can still cancel it. With a separate group it just sat there until it finished. One group, one expression, less machinery.

| trigger | group | cancels others |
|---|---|---|
| `pull_request` | `quorum-review-<n>` | yes |
| `workflow_dispatch` | `quorum-review-<n>` | yes |
| `issue_comment` (human) | `quorum-review-<n>` | yes |
| `issue_comment` (the bot) | `quorum-review-<n>` | **no** |
| `pull_request_review_comment` (the bot) | `quorum-review-<n>` | **no** |

Second time today upstream's shape has been the better one — the fork guard was the first ([#43](https://github.com/yuting0624/antigravity-for-claude-code/pull/43)). Staying close to the example is the point of tracking it.

No plugin code touched. 191 tests, validate passes.