### PR TITLE
ci: teach the review the failure classes this repo actually ships

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -58,6 +58,30 @@ jobs:
             - **Cost discipline**: changes that would put bulky output into the
               conductor's context (dumps instead of digests) are a regression.
 
+            Failure classes this repo has actually shipped — check for them by name,
+            they keep recurring and generic review does not look for them:
+
+            - **A test that passes for the wrong reason.** A new assignment upstream of
+              an existing assertion that voids it; a negative assertion (`grep -q ... &&
+              FAIL`) on a variable that is empty or clobbered, which passes for free
+              while `PASS` still increments. If a test would pass against the unfixed
+              code, it is not a regression test.
+            - **A guard that is a silent no-op.** A workflow job declaring narrower
+              `permissions:` than the API it calls needs (it 403s, and if a later job
+              `needs:` it, that job becomes unreachable); an `if:` reading a payload
+              field the triggering event does not carry, where `null != true` coerces
+              to true. Note that local verification with a developer's `gh` session
+              cannot surface either — say so rather than assuming it was tested.
+            - **Doc drift across more than the file in the diff.** A behavioural claim
+              lives in `README.md`, `SKILL.md`, `docs/POC-PLAYBOOK.md`,
+              `docs/TROUBLESHOOTING.md`, `commands/*.md`, `agents/*.md` *and* in runtime
+              strings in `scripts/*.sh`. Changing one is usually wrong. Grep for the
+              claim, not for the file.
+            - **A claim the diff does not back.** Statements in the PR description or in
+              comments that the code no longer does, and any assertion about `agy`
+              behaviour that was not measured — this repo's convention is to say what
+              was verified, on which version, and what was not.
+
             Be concise and specific. Prefer a few high-confidence findings over a long
             list. If the PR looks good, say so briefly rather than inventing nits.
 


### PR DESCRIPTION
**This is not the narrowing I proposed three times.** I finally counted, and the premise was
wrong.

## The measurement

Across the five PRs where both reviewers ran:

| PR | quorum confirmed | Claude review, real findings |
|---|---|---|
| #39 | 0 (1 refuted) | **4** |
| #41 | 2 — **one a false positive** | 2 |
| #42 | 0 | 0 |
| #43 | 0 | 1 |
| #45 | 0 | 0 |

**They duplicated exactly one finding** (the fork-guard hole on #41, found by both). So there
is no duplication to remove — and narrowing the Claude review to "contracts and drift only"
would have cut the reviewer producing roughly seven real findings to make room for one that
has produced one real and one false.

Worth saying plainly since I argued the other way repeatedly: the generic bullets in that
prompt (shell semantics, portability) are where it found the `--paginate --jq` per-page
behaviour, the unguarded `--help` probe, and the test that had voided its own assertion.
Those are exactly what would have been dropped.

## What this does instead

Adds four failure classes it has caught **here**, named so it keeps looking:

- **A test that passes for the wrong reason** — an assignment upstream of an existing
  assertion that voids it; a negative assertion on an empty or clobbered variable, which
  passes for free while `PASS` still increments. *If it would pass against the unfixed code,
  it is not a regression test.*
- **A guard that is a silent no-op** — a job declaring narrower `permissions:` than the API it
  calls (403s, and anything that `needs:` it becomes unreachable); an `if:` reading a payload
  field the event doesn't carry, where `null != true` coerces to true. Including the note that
  a developer's local `gh` session **cannot** surface either.
- **Doc drift beyond the file in the diff** — behavioural claims live in README, SKILL.md,
  POC-PLAYBOOK, TROUBLESHOOTING, `commands/`, `agents/` *and* in runtime strings in
  `scripts/`. The `--yolo` correction touched eight places.
- **A claim the diff does not back** — in the PR body or in comments.

Every one of these shipped in this repo in the last two days.

No plugin code touched. 191 tests, validate passes.