### PR TITLE
ci: give quorum this repo's criteria, and let it see every push

### DIFF
--- a/.github/quorum/plugin-review.md
+++ b/.github/quorum/plugin-review.md
@@ -1,0 +1,113 @@
+---
+name: plugin-review
+description: Review criteria for the Antigravity for Claude Code plugin — a bash + markdown Claude Code plugin that delegates work to Google's Antigravity CLI (`agy`).
+---
+
+# What this repository is
+
+A Claude Code plugin, written in **bash and markdown**, that hands well-scoped work to a
+second AI (Google's Antigravity CLI, `agy`, running Gemini) and verifies the result. There
+is almost no application code: the artefacts are shell wrappers, hooks, a skill document,
+and slash-command definitions. Review it accordingly — the risks live in shell semantics,
+in a security gate, in a set of machine-readable contracts, and in documentation that makes
+claims about a fast-moving upstream CLI.
+
+CI already runs the test suite, `shellcheck --severity=error`, and `claude plugin validate`.
+Do not repeat those. Everything below is what CI cannot check.
+
+# Contracts that must not drift
+
+These are consumed by other programs, not just read by humans. A change that breaks one is a
+break for callers even when every test passes.
+
+**Exit codes** — `scripts/agy-delegate.sh` and `scripts/agy-job.sh` promise:
+
+```
+0 ok · 1 usage · 2 agy failed · 3 empty · 10 quota · 11 auth · 12 timeout
+13 agy missing · 14 model unavailable · 15 permission denied
+```
+
+The same table appears in `docs/TROUBLESHOOTING.md` and in `skills/antigravity/SKILL.md`. If
+a diff adds, removes or repurposes a code, all three move together or it is a bug.
+
+**Machine-readable stderr lines** — `AGY_SIGNAL {...}` (a classified failure) and
+`AGY_USAGE {...}` (executor token accounting). Both must stay single-line and valid JSON;
+orchestrators parse them. `AGY_USAGE`'s semantics are specific and easy to get backwards:
+`total = input + output`, `thinking` is *inside* `output`, and **`cache_read` is a separate
+counter — not part of `total`, not a subset of `input`**. Anything that prices the Gemini
+side using a different arrangement is wrong.
+
+**Version sync** — `.claude-plugin/plugin.json` and `skills/antigravity/SKILL.md` both carry
+a version. They must match.
+
+# The security gate
+
+`hooks/validate-delegate-bash.sh` is the **only** restriction on what the delegate subagent
+is allowed to run. Any change to it deserves disproportionate scrutiny, in both directions:
+
+- a **bypass** — a shell construct that reaches a command the gate believes it blocked
+  (quoting, substitution, chained operators, pipelines it did not anticipate)
+- a **false positive** — a legitimate delegation prompt the gate now refuses, which pushes
+  users toward disabling it
+
+It is designed to **fail closed**. A change that makes it fail open on a parse error or a
+missing dependency is a serious regression even if it looks like robustness.
+
+# Shell correctness
+
+The whole product is shell, and the failure modes are the shell's:
+
+- **Quoting and word splitting**, especially around paths and user-supplied prompts.
+- **`set -euo pipefail` interactions** — a command substitution in an assignment aborts the
+  script when it fails; a function called in an `if` does not. Know which one you are
+  reading.
+- **Exit-code propagation** through pipes, subshells and command substitution. `$?` after a
+  pipeline is the last command's, and the script often needs the first's.
+- **Redirection order.** Redirections apply left to right. `cmd >file 2>/dev/null` attempts
+  the open while stderr is still stderr; failures leak.
+- **Portability: macOS bash 3.2 and BSD userland**, not just GNU. No `declare -A`, no
+  `readarray`, no GNU-only flags on `sed`/`date`/`grep`. This repo's users are heavily macOS.
+- **Temp files and cleanup on every path**, including the timeout and error paths. A
+  trailing `rm -f` does not run when the script is killed; a trap does.
+- **Anything captured with `$(...)`** — a child that inherits stdout and outlives the command
+  holds the pipe open and the substitution never returns.
+
+# Tests
+
+`tests/run-tests.sh` is a hand-rolled harness using a stub `agy`. Judge a new test by one
+question: **would it fail against the code before the fix?** If not, it documents rather than
+detects. Watch for:
+
+- a variable reassigned between where an existing assertion sets it and where that assertion
+  reads it, silently voiding the older check
+- negative assertions (`grep -q X && FAIL`) on a value that may be empty, which pass for free
+- a stub too permissive to exercise the branch the test claims to cover
+
+# Documentation
+
+This repo tracks an upstream CLI that changes fast, so the docs make dated, falsifiable
+claims. Two failure modes:
+
+- **A claim the diff contradicts.** If the code now behaves differently from what
+  `README.md`, `SKILL.md`, `docs/*.md`, `commands/*.md` or `agents/*.md` says, that is a bug
+  in the PR, not a follow-up.
+- **A claim changed in one place only.** A behavioural statement about `agy` typically lives
+  in several documents **and in runtime strings inside `scripts/*.sh`** — a warning the
+  wrapper prints is documentation too, and it is the copy users actually hit. Search for the
+  claim, not for the file.
+
+Statements about `agy` behaviour should say what was verified and on which version. Flag
+confident claims that were not measured.
+
+# Cost discipline
+
+The plugin exists to keep bulky work off the expensive model. A change that routes raw
+output — full file contents, whole logs, transcripts — into the conductor's context instead
+of a digest defeats the point, even when it is otherwise correct. Cost figures in docs are
+estimates and should be labelled as such.
+
+# What not to spend findings on
+
+Style, formatting and naming preferences; anything `shellcheck` at error severity already
+catches; re-litigating a documented design decision the diff is not changing. A few
+high-confidence findings are worth more here than a long list.

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -23,12 +23,13 @@
 name: quorum-review
 
 on:
-  # Deliberately NOT `synchronize` yet. This is on trial as a second reviewer;
-  # reviewing every push doubles the spend before we know it earns it. Add
-  # `synchronize` once it has: `incremental: on` (the default) then reads only
-  # the range since the last review, so a push costs roughly its own size.
+  # `synchronize` is on now. Without it this only ever saw the FIRST push, which
+  # made it look worse than it is: on #39 it reviewed fb18145 and every later
+  # commit — including the fixes it might have had something to say about — went
+  # only to the other reviewer. `incremental: on` (the default) means a re-review
+  # reads the range since the last one, so a push costs roughly its own size.
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
   # `@quorum /review` on a pull request runs it on demand in the meantime.
   issue_comment:
     types: [created]
@@ -189,13 +190,19 @@ jobs:
         with:
           mode: vertex
           google-cloud-project: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
-          # A built-in skill, unmodified, on purpose. This is on trial against a
-          # known answer key, and a skill written to match that key would find
-          # it by construction and tell us nothing. If recall turns out to be
-          # poor on shell — the built-ins are tuned for application code, and
-          # this repository is bash — the fix is a repo skill at
-          # `.github/quorum/<name>.md`, measured as a separate arm.
-          skill: code-quality-review
+          # Was a built-in, unmodified, while this ran against a known answer key
+          # (#40) — a skill written to match that key would have found it by
+          # construction. That measurement is done, and keeping the generic skill
+          # now just means running a worse reviewer on real pull requests: the
+          # built-ins are tuned for application code and this repository is bash
+          # and markdown.
+          #
+          # Written from the contracts this repo already documents, NOT from what
+          # this reviewer previously missed — fitting it to past misses would make
+          # any later recall number meaningless. Deliberately not a copy of
+          # claude-review.yml's prompt either: two reviewers reading the same
+          # words are not two independent reads.
+          skill: .github/quorum/plugin-review.md
           # MEASURED, not copied from the docs: `claude-sonnet-5` is served in
           # `global` and returns FAILED_PRECONDITION ("not servable in region")
           # in us-central1 for this project. Both models are pinned to the same

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,10 @@ shellcheck scripts/*.sh tests/*.sh   # CI gates on --severity=error
 
 - Small, focused PRs. Describe *what changed and why*; link the issue.
 - Match the surrounding style — POSIX-ish bash, `set -euo pipefail`, quote expansions.
+- **Target bash 3.2.** macOS still ships `/bin/bash` 3.2.57 (GPLv3 is why), and macOS is a
+  supported platform, so `declare -A`, `readarray`/`mapfile`, `${var^^}` and friends are out.
+  Same for GNU-only flags on `sed`, `date` and `grep` — BSD userland is the floor. Testing on
+  Linux only will not catch these.
 - New scripts get a `usage()` and a test in `tests/run-tests.sh`.
 
 ## Reporting bugs / ideas


### PR DESCRIPTION
You asked whether it's legitimate to change the skill now, given I set the
built-in-unmodified condition myself. Working through it:

**The condition was for the backtest.** It existed because #40 had a *known answer key* — a
skill written with that key in mind finds it by construction and measures nothing. That
measurement is finished (2/3, no false positives). Live PRs have no answer key, so the same
contamination can't occur.

**Keeping it costs real quality.** The built-ins are tuned for application code; this repo is
bash and markdown. On #39 quorum reviewed `fb18145` — which already contained both the
`$out` clobber and the unguarded `--help` probe — and reported neither. Holding the generic
skill to preserve a measurement means paying for that measurement in missed findings, every PR.

## What this costs, stated plainly

**The clean prompt-vs-model attribution.** If recall improves from here, that is *not*
evidence Flash+Sonnet are sufficient, because the prompt moved at the same time.

That question is recoverable, and in a better form: hold this skill fixed and swap
`primary-model` / `verifier-model` on the same PRs. That isolates models with the prompt
constant — which is the actual question, and which the current setup (different prompt *and*
different models) could never have answered. Worth doing before spending on a Pro + Opus
upgrade, since if the gap was the prompt, the upgrade buys nothing.

## Two constraints I held, both checkable

**Not a copy of `claude-review.yml`'s prompt.** Two reviewers reading the same words are not
two independent reads. Measured: **0 identical sentences**, vocabulary Jaccard **0.26** —
same subject, independently written.

**Written from contracts this repo already documents, not from what quorum missed.** Fitting
a skill to past misses makes any later recall number meaningless.

That second constraint caught something. `macOS bash 3.2` appears **nowhere in this
repository** — only inside the two review prompts — so the skill had no source for it. It's a
real constraint (`/bin/bash` here is 3.2.57; no `declare -A`, no `readarray`) on a platform
`README.md` lists as supported. It's now in `CONTRIBUTING.md` under Conventions, which is
where it should have been all along.

## `synchronize` is on

Without it quorum only ever saw the **first** push — which flattered the comparison against
it. On #39 it reviewed `fb18145`; every later commit, including the fixes worth commenting
on, went only to the other reviewer. `incremental: on` (the default) means a re-review reads
the range since the last one, so a push costs roughly its own size.

191 tests, validate passes. No plugin code touched.