### PR TITLE
fix: the bash gate now says why it blocked (#51)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,12 @@ All notable changes to **Antigravity for Claude Code**. Format loosely follows
   risk class on the one file that is the only restriction on what the delegate subagent may
   run, and change one already tells the caller how to fix it.
 - Verified the block set did not move: 22 representative payloads produce identical verdicts
-  before and after, and only the three intended whitespace cases flip. 19 new tests, all
-  confirmed to fail against the previous gate (11 of them) or to pin behaviour that must not
-  regress.
+  before and after, and only the three intended whitespace cases flip. **23 new tests**
+  (191 → 214): 11 fail against the gate as it was, 5 fail against this change's own first
+  attempt, and the rest pin behaviour that must not regress — an internal newline, a newline
+  after an unquoted pipe, an unbalanced quote, and an escaped backslash followed by a bare
+  newline (which is *not* a line continuation, and which the first version of that test got
+  wrong).
 
 ## 0.22.2
 - **Correction: `--yolo` is not the only way to grant a headless write, and we said it was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.22.3
+- **The bash gate now says *why* it blocked** ([#51](https://github.com/yuting0624/antigravity-for-claude-code/issues/51),
+  reported by @potch8228 with a six-case repro table that reproduced exactly).
+  `hooks/validate-delegate-bash.sh` rejects an unquoted newline — correctly, since a bare
+  newline separates commands in bash — but `BLOCK_MSG` was **one fixed string for every
+  rejection**, and the header comment listed the metacharacters it rejects without mentioning
+  newline. So a command refused for a stray trailing `\n` returned character-for-character the
+  same message as one refused for not being `agy-delegate` at all. A caller could not tell
+  "harmless formatting" from "you tried to run something else", and retried the same shape.
+  The gate knew the reason at the moment it decided and threw it away. It now prints it to
+  stderr — the path `BLOCK_MSG` already uses, which Claude Code feeds back to the agent —
+  naming the newline and the remedy, the specific metacharacter, command substitution
+  (including inside double quotes), an unterminated quote, a wrong `argv[0]`, too many pipes,
+  or a non-allowlisted pipeline producer.
+  **The reason never quotes the command back.** It lands in the agent's context and a blocked
+  command routinely carries a delegation prompt; a character name and an offset are enough.
+  `argv[0]` is the one exception — a command name, not content, and most of the diagnostic value.
+- **Leading and trailing whitespace is stripped before scanning.** Line 45 already computed
+  `cmd.strip()` to test for emptiness and discarded it. bash ignores surrounding whitespace, so
+  this cannot change what a command does, and a newline with nothing after it cannot begin a
+  second one — it is the case you hit whenever a command is composed programmatically.
+  **Internal newlines are untouched and still blocked**: `agy-delegate\n  "hi"` is genuinely two
+  commands, so the reporter's case 6 does *not* flip, and neither does a newline after an
+  unquoted pipe. Stripping also cannot rescue an unterminated quote.
+  Not taken: allowing a newline immediately after an unquoted `|`. Safe in isolation, but it
+  means editing the scanner's state machine rather than normalising before it — a different
+  risk class on the one file that is the only restriction on what the delegate subagent may
+  run, and change one already tells the caller how to fix it.
+- Verified the block set did not move: 22 representative payloads produce identical verdicts
+  before and after, and only the three intended whitespace cases flip. 19 new tests, all
+  confirmed to fail against the previous gate (11 of them) or to pin behaviour that must not
+  regress.
+
 ## 0.22.2
 - **Correction: `--yolo` is not the only way to grant a headless write, and we said it was
   in eight places.** A `write_file(<dir>)` entry under `permissions.allow` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,15 @@ All notable changes to **Antigravity for Claude Code**. Format loosely follows
   naming the newline and the remedy, the specific metacharacter, command substitution
   (including inside double quotes), an unterminated quote, a wrong `argv[0]`, too many pipes,
   or a non-allowlisted pipeline producer.
-  **The reason never quotes the command back.** It lands in the agent's context and a blocked
-  command routinely carries a delegation prompt; a character name and an offset are enough.
-  `argv[0]` is the one exception — a command name, not content, and most of the diagnostic value.
+  **The reason never quotes ANY of the command back** — not even `argv[0]`. It lands in the
+  agent's context and a blocked command routinely carries a delegation prompt; a character
+  name and an offset are enough. `argv[0]` looks like a safe exception and is not: `head()`
+  returns `shlex.split(seg)[0]`, the first shell *word*, so `"some prompt text" agy-delegate
+  ...` makes attacker-chosen content `argv[0]`. Restricting it to name-shaped tokens does not
+  help either — an API key is name-shaped. Caught by **both** PR reviewers, whose finding also
+  exposed that the test written to cover it could not fail: it placed the marker after a valid
+  `argv[0]` and behind a `;`, so the scan rejected the command first and the branch under test
+  never ran. Five replacement cases now exercise the branches directly.
 - **Leading and trailing whitespace is stripped before scanning.** Line 45 already computed
   `cmd.strip()` to test for emptiness and discarded it. bash ignores surrounding whitespace, so
   this cannot change what a command does, and a newline with nothing after it cannot begin a

--- a/hooks/validate-delegate-bash.sh
+++ b/hooks/validate-delegate-bash.sh
@@ -73,10 +73,6 @@ def deny(reason):
     sys.stderr.write("[antigravity-delegate] reason: %s\n" % reason)
     sys.exit(2)
 
-def shown(tok):                      # argv[0] only: printable, bounded
-    t = "".join(ch if ch.isprintable() else "?" for ch in str(tok))
-    return t if len(t) <= 40 else t[:37] + "..."
-
 CHAR_NAMES = {";": "';' (command separator)", "&": "'&' (background / chaining)",
               "<": "'<' (redirection)",       ">": "'>' (redirection)",
               "(": "'(' (subshell)",          ")": "')' (subshell)",
@@ -157,17 +153,17 @@ if len(segs) == 1:
     if not t:
         deny("the command could not be tokenised")
     if base(t) not in WRAPPERS:
-        deny("the first command is `%s`, not agy-delegate or agy-job" % shown(t))
+        deny("the first command is not agy-delegate or agy-job")
     sys.exit(0)
 elif len(segs) == 2:
     lt, rt = head(segs[0]), head(segs[1])
     if not lt or not rt:
         deny("one side of the pipe could not be tokenised")
     if base(lt) not in PRODUCERS:
-        deny("the left side of the pipe is `%s`; only git, cat, echo or printf may feed "
-             "the wrapper" % shown(lt))
+        deny("the left side of the pipe is not allowed — only git, cat, echo or "
+             "printf may feed the wrapper")
     if base(rt) not in WRAPPERS:
-        deny("the right side of the pipe is `%s`, not agy-delegate or agy-job" % shown(rt))
+        deny("the right side of the pipe is not agy-delegate or agy-job")
     sys.exit(0)
 else:
     deny("%d pipes — at most one is allowed, as `<git|cat|echo|printf> | agy-delegate -`"

--- a/hooks/validate-delegate-bash.sh
+++ b/hooks/validate-delegate-bash.sh
@@ -14,10 +14,17 @@
 #   * allows only one pipeline shape, `<git|cat|echo|printf> | agy-delegate|agy-job -`,
 #     so `git diff | agy-delegate -` keeps working;
 #   * rejects UNQUOTED shell metacharacters bash would act on (`; & | < > ( ) #`,
-#     backticks, `$(`), while permitting them INSIDE a quoted prompt (no false
-#     positives on legitimate prompts — command substitution inside double quotes is
-#     still blocked because bash would expand it);
+#     backticks, `$(`, and a NEWLINE — it separates commands just like `;`), while
+#     permitting them INSIDE a quoted prompt (no false positives on legitimate
+#     prompts — command substitution inside double quotes is still blocked because
+#     bash would expand it). Leading/trailing whitespace is stripped first, so a
+#     trailing newline is fine; an internal one is two commands and stays blocked;
 #   * fails CLOSED (block) if the JSON is unparseable or python3 is unavailable.
+#
+# On a block it prints the SPECIFIC reason to stderr before the generic message
+# (issue #51). Claude Code feeds PreToolUse stderr back to the agent, so the caller
+# can tell "you left a newline in" apart from "you tried to run something else" —
+# previously both produced the same string and the agent retried the same shape.
 #
 # Input: hook JSON on stdin, with .tool_input.command holding the bash command.
 # Exit: 0 = allow, 2 = block.
@@ -26,7 +33,7 @@ set -uo pipefail
 
 input="$(cat)"
 
-BLOCK_MSG="[antigravity-delegate] blocked: this subagent may only run agy-delegate / agy-job (optionally as \`<git|cat|echo|printf> | agy-delegate -\`). No other commands, chaining, redirection, substitution, or comments. Delegate file work to agy; verification is the caller's job."
+BLOCK_MSG="[antigravity-delegate] blocked: this subagent may only run agy-delegate / agy-job (optionally as \`<git|cat|echo|printf> | agy-delegate -\`). No other commands, chaining, redirection, substitution, comments, or unquoted newlines. Delegate file work to agy; verification is the caller's job."
 
 # python3 gives a correct, quote-aware parse. Fail CLOSED if it's missing.
 if ! command -v python3 >/dev/null 2>&1; then
@@ -45,8 +52,35 @@ except Exception:
 if not isinstance(cmd, str) or not cmd.strip():
     sys.exit(2)
 
+# Leading/trailing whitespace is normalised away BEFORE scanning (issue #51). bash
+# ignores it, so this cannot change what the command does — and a newline with
+# nothing after it cannot begin a second command. Internal newlines are untouched
+# and still rejected below. An unterminated quote still fails the state check:
+# `agy-delegate "hi\n` strips to `agy-delegate "hi`, which is still unbalanced.
+cmd = cmd.strip()
+
 WRAPPERS  = {"agy-delegate", "agy-job"}
 PRODUCERS = {"git", "cat", "echo", "printf"}
+
+# Say WHY, on stderr, so the caller can self-correct (issue #51). Claude Code feeds
+# PreToolUse stderr back to the agent, which is the same path BLOCK_MSG already takes.
+#
+# NEVER include the command text. This lands in the agent's context and the blocked
+# command routinely carries a delegation prompt the caller would not want quoted back;
+# a character name and an offset are enough to fix it. `argv[0]` is the exception —
+# it is a command name, not content, and naming it is most of the diagnostic value.
+def deny(reason):
+    sys.stderr.write("[antigravity-delegate] reason: %s\n" % reason)
+    sys.exit(2)
+
+def shown(tok):                      # argv[0] only: printable, bounded
+    t = "".join(ch if ch.isprintable() else "?" for ch in str(tok))
+    return t if len(t) <= 40 else t[:37] + "..."
+
+CHAR_NAMES = {";": "';' (command separator)", "&": "'&' (background / chaining)",
+              "<": "'<' (redirection)",       ">": "'>' (redirection)",
+              "(": "'(' (subshell)",          ")": "')' (subshell)",
+              "#": "'#' (comment)"}
 
 def base(tok):
     b = os.path.basename(tok)
@@ -55,7 +89,13 @@ def base(tok):
 # Quote-aware scan: split into pipeline segments on UNQUOTED '|', and flag any
 # unquoted metacharacter bash would act on (plus command substitution inside "").
 def scan(s):
-    segs, cur, st, i, n, bad = [], [], "U", 0, len(s), False
+    # `bad` carries the REASON (a string) rather than a bool — the gate already knew
+    # why it was rejecting and used to throw that away, which made a stray newline
+    # indistinguishable from "you tried to run something else" (issue #51).
+    segs, cur, st, i, n, bad = [], [], "U", 0, len(s), None
+    def flag(what, pos, hint=""):
+        # First reason wins; position first so the sentence reads in order.
+        return bad or "%s at character %d.%s" % (what, pos + 1, hint)
     while i < n:
         c = s[i]
         if st == "U":
@@ -66,11 +106,16 @@ def scan(s):
                 if i + 1 < n: cur.append(s[i + 1]); i += 2; continue
                 i += 1; continue
             if c == "|":  segs.append("".join(cur)); cur = []; i += 1; continue
-            if c == "`":  bad = True; cur.append(c); i += 1; continue
+            if c == "`":  bad = flag("backtick command substitution", i); cur.append(c); i += 1; continue
             if c == "$":
-                if i + 1 < n and s[i + 1] == "(": bad = True
+                if i + 1 < n and s[i + 1] == "(": bad = flag("`$(` command substitution", i)
                 cur.append(c); i += 1; continue
-            if c in ";&<>()#\n": bad = True; cur.append(c); i += 1; continue
+            if c == "\n":
+                bad = flag("an unquoted newline", i,
+                           " bash treats it as a command separator, so this is two commands."
+                           " Quote the argument, or end the line with a backslash to continue it.")
+                cur.append(c); i += 1; continue
+            if c in ";&<>()#": bad = flag("unquoted %s" % CHAR_NAMES[c], i); cur.append(c); i += 1; continue
             cur.append(c); i += 1; continue
         if st == "S":
             cur.append(c)
@@ -82,19 +127,23 @@ def scan(s):
         if c == "\\":
             if i + 1 < n: cur.append(s[i + 1]); i += 2; continue
             i += 1; continue
-        if c == "`": bad = True; i += 1; continue
+        if c == "`": bad = flag("backtick command substitution inside double quotes "
+                                "(bash still expands it)", i); i += 1; continue
         if c == "$":
-            if i + 1 < n and s[i + 1] == "(": bad = True
+            if i + 1 < n and s[i + 1] == "(":
+                bad = flag("`$(` command substitution inside double quotes "
+                           "(bash still expands it)", i)
             i += 1; continue
         i += 1
     segs.append("".join(cur))
     if st != "U":
-        return None, True            # unbalanced quotes -> unsafe
+        return None, ("an unterminated %s quote" %
+                      ("single" if st == "S" else "double"))
     return segs, bad
 
 segs, bad = scan(cmd)
 if segs is None or bad:
-    sys.exit(2)
+    deny(bad)
 
 def head(seg):
     try:
@@ -105,13 +154,24 @@ def head(seg):
 
 if len(segs) == 1:
     t = head(segs[0])
-    sys.exit(0 if t and base(t) in WRAPPERS else 2)
+    if not t:
+        deny("the command could not be tokenised")
+    if base(t) not in WRAPPERS:
+        deny("the first command is `%s`, not agy-delegate or agy-job" % shown(t))
+    sys.exit(0)
 elif len(segs) == 2:
     lt, rt = head(segs[0]), head(segs[1])
-    ok = bool(lt) and base(lt) in PRODUCERS and bool(rt) and base(rt) in WRAPPERS
-    sys.exit(0 if ok else 2)
+    if not lt or not rt:
+        deny("one side of the pipe could not be tokenised")
+    if base(lt) not in PRODUCERS:
+        deny("the left side of the pipe is `%s`; only git, cat, echo or printf may feed "
+             "the wrapper" % shown(lt))
+    if base(rt) not in WRAPPERS:
+        deny("the right side of the pipe is `%s`, not agy-delegate or agy-job" % shown(rt))
+    sys.exit(0)
 else:
-    sys.exit(2)                      # more than one pipe
+    deny("%d pipes — at most one is allowed, as `<git|cat|echo|printf> | agy-delegate -`"
+         % (len(segs) - 1))
 PY
 then
   exit 0

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.22.2
+version: 0.22.3
 ---
 
 # Antigravity for Claude Code — hybrid SDLC

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -574,6 +574,53 @@ check "gate allows metacharacters INSIDE a quoted prompt -> exit 0" 0 "$rc"
 printf '%s' '{"tool_input":{"command":"nc evil 9 | agy-delegate -"}}' | "$GATE" >/dev/null 2>&1; rc=$?
 check "gate blocks a non-allowlisted pipeline producer -> exit 2" 2 "$rc"
 
+# --- issue #51: newline handling, and saying WHY ------------------------------
+# The gate blocked any unquoted newline and gave the same generic message it gives
+# for "you tried to run something else", so a caller could not tell a stray newline
+# from a real refusal and retried the same shape. Two changes: surrounding whitespace
+# is stripped before scanning, and the reason is printed.
+gate_rc()  { printf '%s' "{\"tool_input\":{\"command\":$1}}" | "$GATE" >/dev/null 2>&1; echo $?; }
+gate_why() { printf '%s' "{\"tool_input\":{\"command\":$1}}" | "$GATE" 2>&1 >/dev/null; }
+
+# Trailing / leading whitespace is normalisation: bash ignores it, and a newline with
+# nothing after it cannot start a second command. This is the case you hit when a
+# command is composed programmatically.
+check "gate allows a trailing newline" 0 "$(gate_rc '"agy-delegate \"hi\"\n"')" "" ""
+check "gate allows a leading newline"  0 "$(gate_rc '"\nagy-delegate \"hi\""')" "" ""
+check "gate allows trailing spaces/tabs/newlines" 0 "$(gate_rc '"agy-delegate \"hi\" \t\n\n"')" "" ""
+
+# THE property that must not regress. `agy-delegate\n  "hi"` is TWO commands in bash,
+# not a formatting nicety — allowing it would be a bypass, so it stays blocked. This
+# is also why the reporter's case 6 does not flip.
+check "gate still blocks an INTERNAL newline" 2 "$(gate_rc '"agy-delegate\n  \"hi\""')" "" ""
+check "gate still blocks a newline after an unquoted pipe" 2 "$(gate_rc '"git diff |\n  agy-delegate -"')" "" ""
+check "gate still blocks a newline that starts another command" 2 "$(gate_rc '"agy-delegate x\nfoo"')" "" ""
+# Unchanged from before: quoted newlines and backslash continuations were always fine.
+check "gate allows a newline inside quotes" 0 "$(gate_rc '"agy-delegate \"line1\nline2\""')" "" ""
+# NB: one backslash before the newline. Two (`\\\\` in JSON) is an escaped literal
+# backslash followed by a bare newline — correctly blocked, and an easy test to get wrong.
+check "gate allows a backslash continuation" 0 "$(gate_rc '"agy-delegate \\\n  \"hi\""')" "" ""
+check "gate blocks an ESCAPED backslash then a bare newline" 2 "$(gate_rc '"agy-delegate \\\\\n  \"hi\""')" "" ""
+# Stripping must not rescue an unterminated quote.
+check "stripping does not rescue an unbalanced quote" 2 "$(gate_rc '"agy-delegate \"hi\n"')" "" ""
+
+# The reason has to name the cause, or the message is no better than before.
+check "reason names the newline"        0 0 "unquoted newline"        "$(gate_why '"agy-delegate\n  \"hi\""')"
+check "reason offers the remedy"        0 0 "backslash"               "$(gate_why '"agy-delegate\n  \"hi\""')"
+check "reason names a ';' separator"    0 0 "command separator"       "$(gate_why '"agy-delegate x; foo"')"
+check "reason names substitution"       0 0 "command substitution"    "$(gate_why '"agy-delegate \"$(foo)\""')"
+check "reason names an unbalanced quote" 0 0 "unterminated"           "$(gate_why '"agy-delegate \"hi"')"
+check "reason names the wrong argv[0]"  0 0 "not agy-delegate"        "$(gate_why '"somethingelse --flag x"')"
+check "reason names the pipe count"     0 0 "at most one"             "$(gate_why '"cat f | agy-delegate - | wc"')"
+check "reason names the bad producer"   0 0 "left side of the pipe"   "$(gate_why '"ls | agy-delegate -"')"
+
+# The reason goes into the AGENT'S CONTEXT, and a blocked command routinely carries a
+# delegation prompt. It must describe the syntax, never quote the command back.
+why="$(gate_why '"agy-delegate \"SECRETPROMPTMARKER goes here\"; foo"')"
+if printf '%s' "$why" | grep -q 'SECRETPROMPTMARKER'; then
+  echo "FAIL: block reason echoes the command text back into the agent's context"; FAIL=$((FAIL+1));
+else echo "ok: block reason does not echo the command text"; PASS=$((PASS+1)); fi
+
 AGENT="$ROOT/agents/antigravity-delegate.md"
 tl=$(grep -m1 '^tools:' "$AGENT")
 if [ "$tl" = "tools: Bash, Read, Glob" ]; then echo "ok: delegate agent tools allowlist exact (no Write/Edit)"; PASS=$((PASS+1));

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -610,16 +610,34 @@ check "reason offers the remedy"        0 0 "backslash"               "$(gate_wh
 check "reason names a ';' separator"    0 0 "command separator"       "$(gate_why '"agy-delegate x; foo"')"
 check "reason names substitution"       0 0 "command substitution"    "$(gate_why '"agy-delegate \"$(foo)\""')"
 check "reason names an unbalanced quote" 0 0 "unterminated"           "$(gate_why '"agy-delegate \"hi"')"
-check "reason names the wrong argv[0]"  0 0 "not agy-delegate"        "$(gate_why '"somethingelse --flag x"')"
+check "reason names the wrong first command" 0 0 "not agy-delegate"    "$(gate_why '"somethingelse --flag x"')"
 check "reason names the pipe count"     0 0 "at most one"             "$(gate_why '"cat f | agy-delegate - | wc"')"
 check "reason names the bad producer"   0 0 "left side of the pipe"   "$(gate_why '"ls | agy-delegate -"')"
 
 # The reason goes into the AGENT'S CONTEXT, and a blocked command routinely carries a
-# delegation prompt. It must describe the syntax, never quote the command back.
-why="$(gate_why '"agy-delegate \"SECRETPROMPTMARKER goes here\"; foo"')"
-if printf '%s' "$why" | grep -q 'SECRETPROMPTMARKER'; then
-  echo "FAIL: block reason echoes the command text back into the agent's context"; FAIL=$((FAIL+1));
-else echo "ok: block reason does not echo the command text"; PASS=$((PASS+1)); fi
+# delegation prompt. It must describe the syntax and never quote ANY of the command back.
+#
+# The shapes below are the ones that actually reach the token-naming branches. An earlier
+# version of this test put the marker after a valid argv[0] and behind a `;` — the scan
+# rejected it first, so the branch under test was never executed and the test passed for
+# free. Both PR reviewers found the leak the test was supposed to cover (#52).
+#
+# argv[0] is not a safe exception: head() returns shlex.split(seg)[0], the first shell
+# WORD, so a leading quoted string becomes argv[0]. Restricting to "name-shaped" tokens
+# does not help either — an API key is name-shaped, which is why nothing is echoed at all.
+leak_free() { # $1 = label, $2 = json command, $3 = marker that must not appear
+  local why; why="$(gate_why "$2")"
+  if printf '%s' "$why" | grep -qF "$3"; then
+    echo "FAIL: block reason leaks command text ($1)"; FAIL=$((FAIL+1));
+  elif [ -z "$why" ]; then
+    echo "FAIL: no reason emitted at all ($1) — the assertion below would pass for free"; FAIL=$((FAIL+1));
+  else echo "ok: no command text in the reason ($1)"; PASS=$((PASS+1)); fi
+}
+leak_free "leading quoted token becomes argv[0]" '"\"SECRETPROMPTMARKER text\" agy-delegate \"hi\""' 'SECRETPROMPTMARKER'
+leak_free "right side of a pipe"                 '"git diff | \"SECRETPROMPTMARKER\" agy-delegate -"' 'SECRETPROMPTMARKER'
+leak_free "left side of a pipe"                  '"\"SECRETPROMPTMARKER\" | agy-delegate -"'           'SECRETPROMPTMARKER'
+leak_free "name-shaped token (an API key is)"    '"sk-ant-oat01-SECRETPROMPTMARKER x"'                 'SECRETPROMPTMARKER'
+leak_free "plain wrong command"                  '"SECRETPROMPTMARKER --flag x"'                       'SECRETPROMPTMARKER'
 
 AGENT="$ROOT/agents/antigravity-delegate.md"
 tl=$(grep -m1 '^tools:' "$AGENT")


### PR DESCRIPTION
Closes #51.

@potch8228's report held up on every point — I read the code and reproduced all six cases
rather than taking the table on trust.

## The rejection was right; the silence wasn't

A bare newline separates commands in bash, and this hook is the **only** restriction on what
the `antigravity-delegate` subagent may run, so blocking is correct. The defect is that
`BLOCK_MSG` was one fixed string for *every* rejection. A command refused for a stray trailing
`\n` returned character-for-character the same message as one refused for not being
`agy-delegate` at all — so "harmless formatting" was indistinguishable from "you tried to run
something else", and an agent retried the same shape.

The gate knew the reason at the moment it decided. It threw it away.

It now prints it to stderr — the path `BLOCK_MSG` already takes, which Claude Code feeds back
to the agent:

```
[antigravity-delegate] reason: an unquoted newline at character 13. bash treats it as a
command separator, so this is two commands. Quote the argument, or end the line with a
backslash to continue it.
```

Also covered: the specific metacharacter, command substitution (including inside double
quotes), unterminated quotes, a wrong `argv[0]`, too many pipes, a non-allowlisted producer.

**The reason never quotes ANY of the command back** — not even `argv[0]`. It lands in the
agent's context and a blocked command routinely carries a delegation prompt; a character name
and an offset are enough.

`argv[0]` *looks* like a safe exception and is not — both reviewers caught this. `head()`
returns `shlex.split(seg)[0]`, the first shell **word**, so `"some prompt text" agy-delegate
...` makes attacker-chosen content `argv[0]` and it gets echoed. Restricting it to
name-shaped tokens doesn't help either: `sk-ant-oat01-...` is name-shaped. Nothing from the
command is rendered now — the agent already knows what it sent; what it can't infer is which
rule it broke.

The test written to cover this **could not fail**: it put the marker after a valid `argv[0]`
and behind a `;`, so the scan rejected the command first and the naming branch never ran.
Replaced with five cases that reach the branches directly, plus a guard that fails if no
reason is emitted at all (an empty string satisfies a negative assertion for free).

## Whitespace stripped before scanning

Line 45 already computed `cmd.strip()` to test for emptiness and discarded it. bash ignores
surrounding whitespace, so this cannot change what a command *does*, and a newline with
nothing after it cannot begin a second one — the case you hit whenever a command is composed
programmatically.

**Internal newlines are untouched.** `agy-delegate\n  "hi"` is genuinely two commands, so the
reporter's **case 6 does not flip** — correctly. Nor does a newline after an unquoted pipe.
Stripping cannot rescue an unterminated quote either.

| case | before | after |
|---|---|---|
| single line | 0 | 0 |
| **trailing newline** | 2 | **0** |
| newline inside quotes | 0 | 0 |
| backslash continuation | 0 | 0 |
| newline after unquoted `\|` | 2 | 2 |
| **internal newline between args** | 2 | 2 *(correct — two commands)* |

## Not taken

Allowing a newline immediately after an unquoted `|`. Safe in isolation — bash requires a
command after a pipe and the segment cap holds — but it means editing the scanner's **state
machine**, where `strip()` is normalisation applied *before* parsing. Different risk classes
on the one file where a mistake is catastrophic, and the reason message now tells the caller
exactly how to fix it. Small follow-up with its own tests if it turns out to be a common retry.

## Verification

**The block set did not move.** 22 representative payloads give identical verdicts before and
after; only the three intended whitespace cases flip:

```
old=2 new=0  "agy-delegate \"hi\"\n"
old=2 new=0  "\nagy-delegate \"hi\""
old=2 new=0  "agy-delegate \"hi\" \t\n\n"
CHANGED verdicts: 0
```

23 new tests (191 → 214). **11 verified to fail against the previous gate**, 5 against this PR's own first attempt; the rest pin behaviour that
must not regress (internal newline, after-pipe newline, unbalanced quote, and an escaped
backslash followed by a bare newline — an easy one to get wrong, and I did on the first
attempt).

214 tests, shellcheck clean, `claude plugin validate` passes. 0.22.3.
