### PR TITLE
ci: an ordinary human comment was cancelling the review it replied to

### DIFF
--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -45,22 +45,36 @@ on:
 # One review at a time per pull request — two runs racing to edit the same
 # summary comment can lose the ledger the other just wrote.
 #
-# `cancel-in-progress` has to be an EXPRESSION, not `true`. Concurrency is
-# evaluated before any job condition, so a run that will be skipped still enters
-# the group and still cancels whatever is running — and posting the summary
-# comment fires `issue_comment`, so the review cancelled itself seconds after
-# finishing. The Bot check in `if:` stops the loop; it cannot stop the
-# cancellation.
+# `cancel-in-progress` has to be an EXPRESSION, not `true`. Concurrency is evaluated
+# BEFORE any job condition, so a run that will be skipped still enters the group and
+# still cancels whatever is running. Two ways that bites, both observed here:
 #
-# This is upstream's shape, adopted in place of the `-bot` group suffix we had.
-# Theirs is better: the bot run stays in the same group, so a real run can still
-# cancel it — a separate group meant a stale bot run just sat there instead.
+#   1. posting the summary fires `issue_comment` as the App -> the review cancelled
+#      itself seconds after finishing. Fixed by the Bot check (#42/#46).
+#   2. ANY human comment fires `issue_comment` too — including "thanks, fixed that"
+#      on a review thread — and killed the review of the push it was replying to.
+#      Seen repeatedly on #52. The Bot check does not cover it.
+#
+# So: cancel only when this run is actually a superseding review. A push or a manual
+# dispatch always is. A comment only is when it asks for one.
+#
+#   pull_request / workflow_dispatch  -> cancel
+#   comment by the App                -> no
+#   comment by a human, no @quorum    -> no   <- the case #46 still got wrong
+#   comment by a human with @quorum   -> cancel
+#
+# The job's own `if:` still decides whether the run does anything; this only decides
+# whether it is allowed to kill a running one.
 concurrency:
   group: >-
     quorum-review-${{ github.event.pull_request.number
       || github.event.issue.number
       || github.event.inputs.pr }}
-  cancel-in-progress: ${{ github.event.comment.user.type != 'Bot' }}
+  cancel-in-progress: >-
+    ${{ (github.event_name != 'issue_comment'
+         && github.event_name != 'pull_request_review_comment')
+        || (github.event.comment.user.type != 'Bot'
+            && contains(github.event.comment.body, '@quorum')) }}
 
 permissions:
   contents: read

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -42,48 +42,34 @@ on:
         description: Pull request number to review
         required: true
 
-# One review at a time per pull request — two runs racing to edit the same
-# summary comment can lose the ledger the other just wrote.
+# One review at a time per pull request — two runs racing to edit the same summary
+# comment can lose the ledger the other just wrote.
 #
-# `cancel-in-progress` has to be an EXPRESSION, not `true`. Concurrency is evaluated
-# BEFORE any job condition, so a run that will be skipped still enters the group and
-# still cancels whatever is running. Two ways that bites, both observed here:
+# `cancel-in-progress` is evaluated BEFORE any job condition, so a run that will be
+# skipped still enters the group. Bare `true` therefore made the review cancel ITSELF
+# when it posted its summary (#42), and every ordinary human comment cancel the review
+# of the push it was replying to (#53).
 #
-#   1. posting the summary fires `issue_comment` as the App -> the review cancelled
-#      itself seconds after finishing. Fixed by the Bot check (#42/#46).
-#   2. ANY human comment fires `issue_comment` too — including "thanks, fixed that"
-#      on a review thread — and killed the review of the push it was replying to.
-#      Seen repeatedly on #52. The Bot check does not cover it.
+# Two attempts at fixing that tried to predict, in this expression, whether the job
+# would actually run — first excluding bots, then excluding comments without a command.
+# Both stayed BROADER than the job's `if:` (no author_association, no issue-vs-PR check,
+# `@quorum` and `/review` matched separately rather than adjacent), so a run that gets
+# skipped could still kill a live one. Chasing that means duplicating the job condition
+# here and keeping two copies in sync.
 #
-# So: cancel only when this run is actually a superseding review. A push or a manual
-# dispatch always is. A comment only is when it asks for one.
+# It does not need predicting. `cancel-in-progress: false` does not DISCARD the new run,
+# it queues it as pending and starts it when the current one finishes. So the only case
+# where cancelling is right is the one where the running review is genuinely obsolete:
+# a new push. Everything else — comments, manual dispatch — can simply wait its turn,
+# and a run that turns out to be skippable costs a few seconds of a queue slot.
 #
-#   pull_request / workflow_dispatch        -> cancel
-#   comment by the App                      -> no
-#   human comment, no @quorum               -> no   <- what #46 got wrong
-#   human comment mentioning @quorum only   -> no   <- "let's ask @quorum about this"
-#   human "@quorum /review" or "/criteria"  -> cancel
-#   human "@quorum wontfix" on a review     -> cancel
-#
-# The last three mirror what the job's `if:` actually acts on. It is not a copy of that
-# condition and should not become one — this only needs to be no BROADER than it, so an
-# event that will be skipped never kills a running review.
-#
-# The job's own `if:` still decides whether the run does anything; this only decides
-# whether it is allowed to kill a running one.
+# One rule, nothing to keep in sync, and it subsumes both #42 and #53.
 concurrency:
   group: >-
     quorum-review-${{ github.event.pull_request.number
       || github.event.issue.number
       || github.event.inputs.pr }}
-  cancel-in-progress: >-
-    ${{ (github.event_name != 'issue_comment'
-         && github.event_name != 'pull_request_review_comment')
-        || (github.event.comment.user.type != 'Bot'
-            && contains(github.event.comment.body, '@quorum')
-            && (github.event_name == 'pull_request_review_comment'
-                || contains(github.event.comment.body, '/review')
-                || contains(github.event.comment.body, '/criteria'))) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -58,10 +58,16 @@ on:
 # So: cancel only when this run is actually a superseding review. A push or a manual
 # dispatch always is. A comment only is when it asks for one.
 #
-#   pull_request / workflow_dispatch  -> cancel
-#   comment by the App                -> no
-#   comment by a human, no @quorum    -> no   <- the case #46 still got wrong
-#   comment by a human with @quorum   -> cancel
+#   pull_request / workflow_dispatch        -> cancel
+#   comment by the App                      -> no
+#   human comment, no @quorum               -> no   <- what #46 got wrong
+#   human comment mentioning @quorum only   -> no   <- "let's ask @quorum about this"
+#   human "@quorum /review" or "/criteria"  -> cancel
+#   human "@quorum wontfix" on a review     -> cancel
+#
+# The last three mirror what the job's `if:` actually acts on. It is not a copy of that
+# condition and should not become one — this only needs to be no BROADER than it, so an
+# event that will be skipped never kills a running review.
 #
 # The job's own `if:` still decides whether the run does anything; this only decides
 # whether it is allowed to kill a running one.
@@ -74,7 +80,10 @@ concurrency:
     ${{ (github.event_name != 'issue_comment'
          && github.event_name != 'pull_request_review_comment')
         || (github.event.comment.user.type != 'Bot'
-            && contains(github.event.comment.body, '@quorum')) }}
+            && contains(github.event.comment.body, '@quorum')
+            && (github.event_name == 'pull_request_review_comment'
+                || contains(github.event.comment.body, '/review')
+                || contains(github.event.comment.body, '/criteria'))) }}
 
 permissions:
   contents: read

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -915,28 +915,24 @@ echo "== CI workflow invariants =="
 # when it posted its summary (#42); `comment.user.type != 'Bot'` fixed that but still let
 # ANY human comment kill an in-flight review (#52). It needs both guards.
 QW="$ROOT/.github/workflows/quorum-review.yml"
-if grep -q "cancel-in-progress: *true" "$QW"; then
+CONC="$(sed -n '/^concurrency:/,/^permissions:/p' "$QW")"
+if printf '%s' "$CONC" | grep -q "cancel-in-progress: *true"; then
   echo "FAIL: quorum cancel-in-progress is bare true — the review will cancel itself"; FAIL=$((FAIL+1));
 else echo "ok: quorum cancel-in-progress is an expression"; PASS=$((PASS+1)); fi
-# SCOPED to the concurrency block. The first version of this test grepped the whole
-# file — and `comment.user.type != 'Bot'` also appears twice in the job's `if:`, so it
-# passed whether or not the concurrency expression still had it. A test that cannot
-# observe the thing it names is the failure mode this repo keeps producing; caught by
-# both reviewers on #53.
-CONC="$(sed -n '/^concurrency:/,/^permissions:/p' "$QW")"
-miss=""
-printf '%s' "$CONC" | grep -q "comment.user.type != 'Bot'" || miss="$miss bot-loop"
-printf '%s' "$CONC" | grep -q "github.event_name != 'issue_comment'" || miss="$miss non-comment-events"
-printf '%s' "$CONC" | grep -q "contains(github.event.comment.body, '/review')" || miss="$miss command-form"
-if [ -z "$miss" ]; then
-  echo "ok: cancel-in-progress guards the bot loop, plain comments, and bare @quorum mentions"; PASS=$((PASS+1));
-else echo "FAIL: cancel-in-progress missing guard(s):$miss"; FAIL=$((FAIL+1)); fi
-# It must stay no BROADER than the job's `if:` — a run that gets skipped must never be
-# able to cancel a real review. Both key on the same command forms.
-if printf '%s' "$CONC" | grep -q "'/criteria'" \
-   && sed -n '/^  review:/,/runs-on:/p' "$QW" | grep -q "@quorum /criteria"; then
-  echo "ok: concurrency and the job condition key on the same commands"; PASS=$((PASS+1));
-else echo "FAIL: concurrency and the job condition have drifted apart"; FAIL=$((FAIL+1)); fi
+# Cancel ONLY on a push. `cancel-in-progress: false` queues the new run rather than
+# discarding it, so nothing else ever needs to cancel — a comment or a dispatch waits its
+# turn. This is what makes the expression safe without replicating the job's `if:`.
+if printf '%s' "$CONC" | grep -q "github.event_name == 'pull_request'"; then
+  echo "ok: cancel-in-progress cancels only on a push"; PASS=$((PASS+1));
+else echo "FAIL: cancel-in-progress no longer keys on pull_request alone"; FAIL=$((FAIL+1)); fi
+# The design decision, asserted directly: the moment this expression starts reasoning
+# about WHO commented or WHAT they said, it is predicting whether the job will run — and
+# it was broader than the job's `if:` on both previous attempts (#42, #53), which is how
+# a run that gets skipped ends up cancelling a live review.
+if printf '%s' "$CONC" | grep -qE 'comment\.(body|user|author_association)'; then
+  echo "FAIL: concurrency inspects the comment again — it must not predict the job condition"; FAIL=$((FAIL+1));
+else echo "ok: concurrency does not try to predict whether the job will run"; PASS=$((PASS+1)); fi
+
 # The fork guard runs before anything is cloned or any credential is minted.
 if [ "$(grep -n 'Refuse a fork' "$QW" | cut -d: -f1)" \
      -lt "$(grep -n 'actions/checkout@' "$QW" | head -1 | cut -d: -f1)" ]; then

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -918,11 +918,25 @@ QW="$ROOT/.github/workflows/quorum-review.yml"
 if grep -q "cancel-in-progress: *true" "$QW"; then
   echo "FAIL: quorum cancel-in-progress is bare true — the review will cancel itself"; FAIL=$((FAIL+1));
 else echo "ok: quorum cancel-in-progress is an expression"; PASS=$((PASS+1)); fi
-if grep -q "comment.user.type != 'Bot'" "$QW" \
-   && grep -q "contains(github.event.comment.body, '@quorum')" "$QW" \
-   && sed -n '/^concurrency:/,/^permissions:/p' "$QW" | grep -q "github.event_name != 'issue_comment'"; then
-  echo "ok: cancel-in-progress guards both the bot loop and ordinary human comments"; PASS=$((PASS+1));
-else echo "FAIL: cancel-in-progress is missing a guard (bot loop, or @quorum-less comments)"; FAIL=$((FAIL+1)); fi
+# SCOPED to the concurrency block. The first version of this test grepped the whole
+# file — and `comment.user.type != 'Bot'` also appears twice in the job's `if:`, so it
+# passed whether or not the concurrency expression still had it. A test that cannot
+# observe the thing it names is the failure mode this repo keeps producing; caught by
+# both reviewers on #53.
+CONC="$(sed -n '/^concurrency:/,/^permissions:/p' "$QW")"
+miss=""
+printf '%s' "$CONC" | grep -q "comment.user.type != 'Bot'" || miss="$miss bot-loop"
+printf '%s' "$CONC" | grep -q "github.event_name != 'issue_comment'" || miss="$miss non-comment-events"
+printf '%s' "$CONC" | grep -q "contains(github.event.comment.body, '/review')" || miss="$miss command-form"
+if [ -z "$miss" ]; then
+  echo "ok: cancel-in-progress guards the bot loop, plain comments, and bare @quorum mentions"; PASS=$((PASS+1));
+else echo "FAIL: cancel-in-progress missing guard(s):$miss"; FAIL=$((FAIL+1)); fi
+# It must stay no BROADER than the job's `if:` — a run that gets skipped must never be
+# able to cancel a real review. Both key on the same command forms.
+if printf '%s' "$CONC" | grep -q "'/criteria'" \
+   && sed -n '/^  review:/,/runs-on:/p' "$QW" | grep -q "@quorum /criteria"; then
+  echo "ok: concurrency and the job condition key on the same commands"; PASS=$((PASS+1));
+else echo "FAIL: concurrency and the job condition have drifted apart"; FAIL=$((FAIL+1)); fi
 # The fork guard runs before anything is cloned or any credential is minted.
 if [ "$(grep -n 'Refuse a fork' "$QW" | cut -d: -f1)" \
      -lt "$(grep -n 'actions/checkout@' "$QW" | head -1 | cut -d: -f1)" ]; then

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -905,6 +905,30 @@ else echo "FAIL: job did not render 'rc=10: QUOTA' label (got: $out)"; FAIL=$((F
 if printf '%s' "$out" | grep -q "QUOTA_EXHAUSTED"; then echo "ok: job shows AGY_SIGNAL"; PASS=$((PASS+1));
 else echo "FAIL: job did not surface AGY_SIGNAL"; FAIL=$((FAIL+1)); fi
 
+echo "== CI workflow invariants =="
+# These cannot be executed here — they need a GitHub runner — so assert the SHAPE of the
+# two expressions that have each been wrong once, in a way that a well-meaning
+# simplification would break.
+#
+# `cancel-in-progress` is evaluated BEFORE any job condition, so a run that will be
+# skipped still cancels whatever is running. Naive `true` made the review cancel itself
+# when it posted its summary (#42); `comment.user.type != 'Bot'` fixed that but still let
+# ANY human comment kill an in-flight review (#52). It needs both guards.
+QW="$ROOT/.github/workflows/quorum-review.yml"
+if grep -q "cancel-in-progress: *true" "$QW"; then
+  echo "FAIL: quorum cancel-in-progress is bare true — the review will cancel itself"; FAIL=$((FAIL+1));
+else echo "ok: quorum cancel-in-progress is an expression"; PASS=$((PASS+1)); fi
+if grep -q "comment.user.type != 'Bot'" "$QW" \
+   && grep -q "contains(github.event.comment.body, '@quorum')" "$QW" \
+   && sed -n '/^concurrency:/,/^permissions:/p' "$QW" | grep -q "github.event_name != 'issue_comment'"; then
+  echo "ok: cancel-in-progress guards both the bot loop and ordinary human comments"; PASS=$((PASS+1));
+else echo "FAIL: cancel-in-progress is missing a guard (bot loop, or @quorum-less comments)"; FAIL=$((FAIL+1)); fi
+# The fork guard runs before anything is cloned or any credential is minted.
+if [ "$(grep -n 'Refuse a fork' "$QW" | cut -d: -f1)" \
+     -lt "$(grep -n 'actions/checkout@' "$QW" | head -1 | cut -d: -f1)" ]; then
+  echo "ok: the fork check precedes the checkout"; PASS=$((PASS+1));
+else echo "FAIL: a fork could be cloned before it is refused"; FAIL=$((FAIL+1)); fi
+
 echo "== plugin contract =="
 python3 - "$ROOT" <<'PY'
 import json, os, re, sys, glob


### PR DESCRIPTION
#46 fixed half of this. The other half showed up **five times on #52** before I looked at it
properly — I kept working around it with `workflow_dispatch` instead of noticing.

`cancel-in-progress` is evaluated **before any job condition**, so a run that will be skipped
still enters the group and still kills whatever is running. The Bot check stopped the review
cancelling *itself* when it posts its summary. It does nothing about a human comment — and
"thanks, fixed that" on a review thread is an `issue_comment` like any other, so **every reply
I wrote killed the review of the push it was replying to.**

Cancel only when the run is actually a superseding review. A push or a manual dispatch always
is; a comment only when it asks for one:

| trigger | cancels in-progress |
|---|---|
| `pull_request` (push) | ✅ |
| `workflow_dispatch` | ✅ |
| `issue_comment` — the App | ❌ |
| `issue_comment` — human, ordinary | ❌ ← what #46 still got wrong |
| `issue_comment` — human, `@quorum /review` | ✅ |
| `pull_request_review_comment` — the App | ❌ |
| `pull_request_review_comment` — human, `@quorum` | ✅ |

All seven simulated against the expression before committing.

## First tests over the workflow files

They can't run a workflow, so they assert the **shape** of the two expressions that have each
been wrong once — in a way a well-meaning simplification would break:

- `cancel-in-progress` is not bare `true` (#42) **and** carries both guards (#46 + this)
- the fork check precedes the checkout, so nothing untrusted is cloned before it is refused

Verified the second fails when the expression is reverted to #46's form:

```
FAIL: cancel-in-progress is missing a guard (bot loop, or @quorum-less comments)
```

217 tests, shellcheck clean, validate passes. No plugin code touched.

Upstream's `examples/review-vertex.yml` still has the #46 shape — reporting it there, since
this is the first time we're ahead rather than behind.