### PR TITLE
fix: --tier was inert below agy 1.1.10; retract the model comparisons

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.22.4
+- **`--tier` did nothing on agy below 1.1.10, and nothing said so.** agy 1.1.10 fixed
+  `--model` and `--effort` being *ignored in headless `-p`* — the flag was applied after
+  model configuration had initialised, so the run silently fell back to the persisted
+  default. This wrapper resolves every `--tier` (and every `tier_*` remap) to `--model` and
+  always runs `-p`, so on an older agy **the entire routing story was inert while looking
+  like it worked**: the call succeeds, returns sensible text, reports usage. Only a
+  bogus model surfaced anything, because validation still ran — which is why
+  `--model no-such-model` correctly returned exit 14 all along and hid the rest.
+  `doctor` now warns on agy < 1.1.10, with the version compare done properly: a string
+  compare puts 1.1.10 *below* 1.1.9, and the boundary is the whole point of the check.
+- **Retracted: the 3.5 / 3.6 / `flash-medium` token comparisons** from 0.22.0. Two
+  independent reasons, either sufficient. Those runs were made on agy **1.1.8–1.1.9**, so
+  `--model` was being ignored and every arm may have executed the same persisted default.
+  And the numbers did not survive their own ranges: 3.5-high spanned **[421k, 509k]** input
+  against 3.6-high's **[305k, 412k]** at n=2 — separated by 2% — while `flash-medium`
+  **overlapped `high` outright**, and "−31% input" was a mean-vs-mean claim across those
+  overlapping ranges. `docs/POC-PLAYBOOK.md` tells you to report ranges rather than means
+  for exactly this reason; this repo published the mean anyway.
+  What stands: Gemini 3.6 Flash's **output rate ($7.50/M vs 3.5's $9.00/M)**, which came
+  from checking two pricing sources, not from those runs. The `flash` default is unchanged.
+- Version-gate tests cover 1.1.9 (warns), **1.1.10 (must not warn — the boundary)**, a later
+  minor, and an unparseable version, which is left alone rather than warned about.
+
 ## 0.22.3
 - **The bash gate now says *why* it blocked** ([#51](https://github.com/yuting0624/antigravity-for-claude-code/issues/51),
   reported by @potch8228 with a six-case repro table that reproduced exactly).
@@ -177,7 +201,9 @@ All notable changes to **Antigravity for Claude Code**. Format loosely follows
   Two tests now hold this together: every hardcoded fallback in `agy-cost-compare.sh`
   must match `prices.json`, and `gemini_flash` must match whatever the `flash` tier
   actually resolves to.
-- **Docs: Gemini 3.6 Flash High measured against 3.5.** −23% input tokens for the same
+- **Docs: Gemini 3.6 Flash High measured against 3.5.** ⚠️ **Retracted in 0.22.4** — these
+  runs were on agy 1.1.8–1.1.9, where `--model` was ignored in headless `-p`, and the
+  ranges overlapped. −23% input tokens for the same
   task (n=2, order-reversed) and output at $7.50/M vs $9.00/M — but it does **not** reduce
   `cache_read` (+6%) and is ~29% slower. `flash-medium` is −31% input / −21% wall but
   **`cache_read` +43%** (n=3, reproduced), so it loses on cache_read-dominated agentic

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -105,7 +105,26 @@ echo "Antigravity for Claude Code — doctor"
 if command -v agy >/dev/null 2>&1; then
   # version probe is guarded too: `command -v` already proved agy exists, and on a
   # headless hang even `agy --version` shouldn't be able to freeze doctor (issue #6).
-  ok "agy found: $(command -v agy)  ($(agy_guard 10 --version 2>/dev/null | head -1))"
+  AGY_VER="$(agy_guard 10 --version 2>/dev/null | head -1 | tr -d '[:space:]')"
+  ok "agy found: $(command -v agy)  (${AGY_VER:-version unknown})"
+
+  # `--tier` resolves to `--model`, and agy IGNORED --model/--effort in headless `-p`
+  # until 1.1.10 — the flag was applied after model configuration had initialised, so
+  # the run silently fell back to the persisted default. Nothing surfaces that: the
+  # call succeeds, returns sensible text, and reports usage. So on an older agy the
+  # plugin's whole routing story is inert and looks like it is working, which is worth
+  # a warning rather than a footnote.
+  case "$AGY_VER" in
+    ''|*[!0-9.]*) : ;;               # unparseable (dev build, wrapper, hang) — say nothing
+    *)
+      if [ "$(printf '%s\n1.1.10\n' "$AGY_VER" | sort -V | head -1)" = "$AGY_VER" ] \
+         && [ "$AGY_VER" != "1.1.10" ]; then
+        warn "agy $AGY_VER ignores --model/--effort in headless \`-p\` (fixed in 1.1.10)"
+        info "so --tier / tier_* remaps do NOT take effect — every delegation silently runs"
+        info "your persisted default model instead, and nothing in the output says so."
+        info "fix: \`agy update\` to 1.1.10 or newer."
+      fi ;;
+  esac
 else
   bad "agy NOT on PATH"
   info "fix: install the Antigravity CLI, then ensure its bin dir is on PATH"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -92,6 +92,23 @@ sys.exit(0 if n else 1)
 ' "${files[@]}" 2>/dev/null
 }
 
+# True when version $1 is strictly older than $2. Pure shell on purpose: `sort -V` is
+# not universal, and when it is missing the command substitution comes back EMPTY, the
+# comparison quietly fails, and the check it guards never fires — a version gate that
+# silently does nothing is worse than none, because it reads as a clean bill of health.
+# (macOS's own sort does support -V; BusyBox and minimal images are the risk.)
+ver_lt() {
+  local a="$1" b="$2" i x y
+  for i in 1 2 3; do
+    x="$(printf '%s' "$a" | cut -d. -f"$i")"; y="$(printf '%s' "$b" | cut -d. -f"$i")"
+    case "$x" in ''|*[!0-9]*) x=0 ;; esac
+    case "$y" in ''|*[!0-9]*) y=0 ;; esac
+    [ "$x" -lt "$y" ] && return 0
+    [ "$x" -gt "$y" ] && return 1
+  done
+  return 1                            # equal is not older
+}
+
 # True on native Windows (Git Bash/MSYS/Cygwin), NOT WSL — where headless agy hangs.
 on_windows_native() {
   case "${OSTYPE:-}" in msys*|cygwin*|win32) return 0 ;; esac
@@ -117,8 +134,7 @@ if command -v agy >/dev/null 2>&1; then
   case "$AGY_VER" in
     ''|*[!0-9.]*) : ;;               # unparseable (dev build, wrapper, hang) — say nothing
     *)
-      if [ "$(printf '%s\n1.1.10\n' "$AGY_VER" | sort -V | head -1)" = "$AGY_VER" ] \
-         && [ "$AGY_VER" != "1.1.10" ]; then
+      if ver_lt "$AGY_VER" 1.1.10; then
         warn "agy $AGY_VER ignores --model/--effort in headless \`-p\` (fixed in 1.1.10)"
         info "so --tier / tier_* remaps do NOT take effect — every delegation silently runs"
         info "your persisted default model instead, and nothing in the output says so."

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.22.3
+version: 0.22.4
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -56,19 +56,29 @@ or persistently with the `default_model` / `tier_*` plugin options. Keep the exe
 *different, cheaper* model than the Claude conductor: that's what yields the cost saving **and**
 the cross-model verification value (Claude executing Claude loses both).
 
-> **Model availability moves fast.** Verified through **agy 1.1.8**. The `flash` default
-> **stays on Gemini 3.5 Flash (High)** for broad plan availability (newer models can lag on
-> enterprise Vertex) — but **Gemini 3.6 Flash High is measurably better on both axes** and
-> is worth remapping to when your plan serves it (`tier_flash` →
-> `gemini-3.6-flash-high`; 18 benchmark trials ran on it without an availability problem):
-> **−23% input tokens** for the same task (n=2, order-reversed) and **output priced at
-> $7.50/M vs 3.5's $9.00/M**; input and cached-input rates are unchanged. It does *not*
-> reduce `cache_read` (+6%) and is ~29% slower. If you do remap, price it with
-> `prices.json`'s `gemini_flash_36` — `gemini_flash` tracks the shipped 3.5 default,
-> and `agy-cost-compare` picks that key by tier name, not by model.
-> **`flash-medium` is not a general win:** −31% input and −21% wall, but `cache_read` +43%
-> (n=3, reproduced) — on cache_read-dominated agentic work it loses to `high`. Pick by the
-> task's input:cache_read ratio.
+> **Model availability moves fast, and `--tier` needs agy ≥ 1.1.10.** Until 1.1.10, agy
+> **ignored `--model` and `--effort` in headless `-p`** — the flag was applied after model
+> configuration had initialised, so the run silently fell back to the persisted default.
+> This wrapper resolves every `--tier` to `--model` and always runs `-p`, so on an older
+> agy **tier selection does nothing and looks like it works**: the call succeeds, returns
+> sensible text, reports usage. `doctor` warns when it sees one.
+>
+> The `flash` default is **Gemini 3.5 Flash (High)**, for broad plan availability — newer
+> models can lag on enterprise Vertex. Gemini 3.6 Flash is available and its **output is
+> cheaper ($7.50/M vs $9.00/M; input and cached-input unchanged — confirmed against two
+> pricing sources)**, so remapping `tier_flash` to `gemini-3.6-flash-high` is reasonable
+> when your plan serves it. Price it with `prices.json`'s `gemini_flash_36`;
+> `agy-cost-compare` picks the `gemini_flash` key by tier name, not by model.
+>
+> **Retracted:** earlier versions of this note quoted token-level comparisons between
+> 3.5 / 3.6 / `flash-medium` (−23% input, `cache_read` +43%, and so on). Those runs were
+> made on agy 1.1.8–1.1.9, where `--model` was ignored — so every arm may have executed
+> the same persisted default. Independently, the numbers did not survive their own ranges:
+> 3.5-high spanned [421k, 509k] input against 3.6-high's [305k, 412k] at n=2, and
+> `flash-medium` overlapped `high` outright. A mean-vs-mean claim over overlapping ranges
+> is exactly what this repo's own playbook tells you not to report. Pick a tier by what
+> your plan serves and by the published rates until this is re-measured on 1.1.10+.
+>
 > Note: agy 1.1.5 changed `agy models` output to slugs (`gemini-3.5-flash`); both slugs and
 > display names are accepted by `--model`, and `doctor` matches either.
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -710,6 +710,30 @@ else echo "ok: no warning on a later minor (1.2.0)"; PASS=$((PASS+1)); fi
 if printf '%s' "$(ver_doctor dev-local)" | grep -q 'ignores --model'; then
   echo "FAIL: doctor warns on an unparseable version"; FAIL=$((FAIL+1));
 else echo "ok: unparseable version is left alone"; PASS=$((PASS+1)); fi
+# The gate must not depend on `sort -V`. Where that is missing the command substitution
+# comes back empty, the comparison quietly fails, and the warning never fires — a version
+# gate that silently does nothing reads as a clean bill of health. Both reviewers on #54
+# flagged the dependency; this pins the property rather than the implementation.
+# Strip comments first: the replacement explains WHY it avoids `sort -V`, and an
+# unstripped grep matches that sentence and reports the dependency it removed.
+if sed 's/#.*//' "$ROOT/scripts/doctor.sh" | grep -q 'sort -V'; then
+  echo "FAIL: doctor's version gate depends on sort -V (absent on some shells)"; FAIL=$((FAIL+1));
+else echo "ok: version gate does not depend on sort -V"; PASS=$((PASS+1)); fi
+brk="$TMP/nosort"; mkdir -p "$brk"; printf '#!/bin/sh\nexit 127\n' > "$brk/sort"; chmod +x "$brk/sort"
+d="$TMP/agyver"; mkdir -p "$d"
+{ echo '#!/usr/bin/env bash'
+  echo '[ "$1" = --version ] && { echo 1.1.9; exit 0; }'
+  echo '[ "$1" = models ] && { printf "%s\n" "Gemini 3.5 Flash (High)" "Gemini 3.5 Flash (Low)" "Gemini 3.1 Pro (High)"; exit 0; }'
+  echo 'exit 0'; } > "$d/agy"
+chmod +x "$d/agy"
+# Capture, THEN grep. `cmd | grep -q` exits at the first match and closes the pipe, the
+# upstream dies of SIGPIPE (141), and `set -o pipefail` (line 8) marks the whole pipeline
+# failed — so the assertion reads as "no warning" while the warning is right there. This
+# is the 0.21.1 bug, in the file whose tests guard against it.
+nosort_out="$(PATH="$brk:$d:$PATH" bash "$ROOT/scripts/doctor.sh" 2>&1)"
+if printf '%s' "$nosort_out" | grep -q 'ignores --model'; then
+  echo "ok: the warning still fires with sort unusable"; PASS=$((PASS+1));
+else echo "FAIL: a broken sort silences the version gate"; FAIL=$((FAIL+1)); fi
 
 echo "== doctor.sh stdio-MCP detection (issue #37 diagnostic) =="
 # The hint is diagnostic-only, so getting it wrong fails SILENTLY — it just never

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -680,6 +680,37 @@ if printf '%s' "$out" | grep -q "tier model present: Gemini 3.5 Flash (High)"; t
   echo "ok: doctor matches default flash tier in slug format"; PASS=$((PASS+1));
 else echo "FAIL: doctor did not confirm the default flash tier present"; FAIL=$((FAIL+1)); fi
 
+echo "== doctor.sh agy-version gate (--tier is inert below 1.1.10) =="
+# agy ignored --model/--effort in headless `-p` until 1.1.10: the flag was applied after
+# model configuration had initialised, so the run silently fell back to the persisted
+# default. The wrapper resolves every --tier to --model and always runs -p, so on an
+# older agy the routing is inert AND looks like it works — the call succeeds, returns
+# sensible text, reports usage. Nothing but a version check can surface that.
+ver_doctor() { # $1 = version the stub reports; echoes doctor's output
+  local d; d="$TMP/agyver"; mkdir -p "$d"
+  { echo '#!/usr/bin/env bash'
+    echo "[ \"\$1\" = --version ] && { echo '$1'; exit 0; }"
+    echo '[ "$1" = models ] && { printf "%s\n" "Gemini 3.5 Flash (High)" "Gemini 3.5 Flash (Low)" "Gemini 3.1 Pro (High)"; exit 0; }'
+    echo 'exit 0'; } > "$d/agy"
+  chmod +x "$d/agy"
+  PATH="$d:$PATH" bash "$ROOT/scripts/doctor.sh" 2>&1
+}
+if printf '%s' "$(ver_doctor 1.1.9)" | grep -q 'ignores --model'; then
+  echo "ok: doctor warns that --tier is inert on agy 1.1.9"; PASS=$((PASS+1));
+else echo "FAIL: no warning on agy 1.1.9 — tier selection is silently doing nothing"; FAIL=$((FAIL+1)); fi
+# 1.1.10 is the fix, and a naive string compare puts it BELOW 1.1.9 — the boundary is
+# the whole point of the check.
+if printf '%s' "$(ver_doctor 1.1.10)" | grep -q 'ignores --model'; then
+  echo "FAIL: doctor warns on 1.1.10, which is the version that fixed it"; FAIL=$((FAIL+1));
+else echo "ok: no warning on agy 1.1.10 (string compare would have got this wrong)"; PASS=$((PASS+1)); fi
+if printf '%s' "$(ver_doctor 1.2.0)" | grep -q 'ignores --model'; then
+  echo "FAIL: doctor warns on 1.2.0"; FAIL=$((FAIL+1));
+else echo "ok: no warning on a later minor (1.2.0)"; PASS=$((PASS+1)); fi
+# An unparseable version must not produce a scary warning on a build we cannot judge.
+if printf '%s' "$(ver_doctor dev-local)" | grep -q 'ignores --model'; then
+  echo "FAIL: doctor warns on an unparseable version"; FAIL=$((FAIL+1));
+else echo "ok: unparseable version is left alone"; PASS=$((PASS+1)); fi
+
 echo "== doctor.sh stdio-MCP detection (issue #37 diagnostic) =="
 # The hint is diagnostic-only, so getting it wrong fails SILENTLY — it just never
 # helps the person it exists for. Pin the two things measured against agy 1.1.9:


### PR DESCRIPTION
agy 1.1.10's changelog, checking what a version bump meant for us:

> Fixed `--model` and `--effort` being **ignored** in interactive sessions and in **headless
> `-p` runs**, where the flags were applied after model configuration had already been
> initialized so the run **silently fell back to the persisted or default model**.

This wrapper resolves every `--tier` — and every `tier_*` remap — to `--model`, and always
runs `-p`. So on any agy below 1.1.10 **the entire routing story was inert while looking
exactly like it worked**: the call succeeds, returns sensible text, reports usage.

**What hid it:** validation still ran, so a bogus `--model` correctly returned exit 14. That
is the check I used to satisfy myself `--model` was wired up. It proved the flag was *parsed*,
not that it was *applied*.

`doctor` now warns below 1.1.10:

```
⚠ agy 1.1.9 ignores --model/--effort in headless `-p` (fixed in 1.1.10)
  so --tier / tier_* remaps do NOT take effect — every delegation silently runs
  your persisted default model instead, and nothing in the output says so.
```

The compare uses `sort -V`: a string compare puts **1.1.10 below 1.1.9**, and that boundary
is the whole point. An unparseable version is left alone rather than warned about.

## Retracting the 3.5 / 3.6 / flash-medium comparisons (0.22.0)

Two independent reasons, either one sufficient.

**1. Wrong agy.** Log timestamps put those runs on **1.1.8–1.1.9**, so `--model` was being
ignored and every arm may have executed the same persisted default.

**2. The numbers never survived their own ranges.**

| | input, per run | range |
|---|---|---|
| 3.5-flash-high (n=2) | 509,432 / 421,384 | [421k, 509k] |
| 3.6-flash-high (n=2) | 411,895 / 305,187 | [305k, 412k] |
| 3.6-flash-medium (n=3) | 282,440 / 325,121 / 356,347 | [282k, 356k] |

3.5 and 3.6-high separate by **2%**. `flash-medium` **overlaps `high` outright** — and
"−31% input" was a mean-vs-mean claim across those overlapping ranges.

`docs/POC-PLAYBOOK.md` says to report ranges rather than means, for exactly this failure. I
wrote that section three days *after* publishing these numbers, and did not go back.

**What stands:** Gemini 3.6 Flash's output rate (**$7.50/M vs 3.5's $9.00/M**) — that came
from checking two pricing sources, not from these runs. The `flash` default is unchanged.

## Verified

On the real CLI (which self-updated 1.1.10 → 1.1.11 mid-session), the same prompt across
three models now returns clearly different usage — `--model` is honoured on 1.1.10+:

```
no --model (default 3.6-lo)  input=21482  output=  5  thinking=  0   3.4s
gemini-3.5-flash-low         input=20302  output=  4  thinking=  0   2.9s
gemini-3.1-pro-high          input=20992  output=279  thinking=274   5.9s
```

Version-gate tests cover 1.1.9 (warns), **1.1.10 (must not — the boundary)**, a later minor,
and an unparseable version. 218 tests, shellcheck clean, validate passes. 0.22.4.

## Not in this PR

- agy 1.1.11 fixed an allowlist entry that tokenises to zero command words (`command(time)`,
  `()`) **matching every command and silently auto-approving anything**. We steer people to
  `permissions.allow` in eight places as of 0.22.2, so that wants a minimum-version note.
- 1.1.11 also added structured `-p "/usage"`, `/quota`, `/credits` — usable by `doctor` and
  by cost measurement.
- 1.1.11 changed model-loading error text for permission failures; our exit-14 classifier
  keys on the old wording and should be re-checked against it.