### PR TITLE
docs: name the other surface this thesis runs on

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ In Claude Code:
 
 ## 🗳️ The same two models, arranged differently
 
-This plugin is one shape of Claude and Gemini working together: **conductor and executor** — judgement on one side, throughput on the other, one workflow.
+This plugin is one shape of Claude and Gemini working together: **conductor and executor** — judgement on one side, throughput on the other, one workflow. It is also the shape for people who live in a terminal.
 
-[**quorum-review**](https://github.com/yuting0624/quorum-review) is the other shape: the two as **peers**. Both read the same pull request independently, neither sees the other's output, and where they agree independently *that is the result* — only the disagreements are worth a second opinion. Both run on **one** Google Cloud credential, so no vendor API keys live in the repository. Same author as this plugin.
+[**gemini-studio-mcp**](https://github.com/yuting0624/gemini-studio-mcp) is the same thesis on the other surface: **Claude Desktop**, for the colleagues who will never open one. An MCP server rather than a CLI delegation, and the verb flips from *execute* to *ingest* — Gemini reads the recording, the PDF corpus, the internal search index, and only the digest reaches Claude. The split is not cosmetic: you can hand a developer a `--tier` flag and an `AGENTS.md`, but a business user drags a PDF into a chat window, so the routing that is explicit here is automatic there, and the cost discipline that is a documented practice here is a number printed on every response there. They also fail differently — delegated *writing* can silently not happen and has to be checked against the filesystem; delegated *reading* can quietly summarise away the one paragraph that mattered and has to be checked against citations. Same author as this plugin.
+
+[**quorum-review**](https://github.com/yuting0624/quorum-review) is the third shape: the two as **peers**. Both read the same pull request independently, neither sees the other's output, and where they agree independently *that is the result* — only the disagreements are worth a second opinion. Both run on **one** Google Cloud credential, so no vendor API keys live in the repository. Same author as this plugin.
 
 **This repo is its client zero.** It runs on every pull request opened here, alongside a Claude review — including the ones that change this plugin. Keeping the habit of not quoting numbers we haven't measured, here is what that has actually been worth:
 


### PR DESCRIPTION
## Why

The "same two models, arranged differently" section names **quorum-review** as the other shape, but stops there — which leaves the surface a non-developer would actually be handed unnamed.

[**gemini-studio-mcp**](https://github.com/yuting0624/gemini-studio-mcp) is this repo's thesis on Claude Desktop: same conductor/executor split, delivered as an MCP server instead of a CLI delegation, with the verb flipped from *execute* to *ingest*.

## What the paragraph argues

Not just "there is also this repo" — why it has to be a separate one:

- **You can teach a developer a `--tier` flag; a business user drags a PDF into a chat window.** So the routing decision that is explicit here is automatic there, and the cost discipline that is a documented practice here is a number printed on every response there.
- **They fail differently.** A delegated *write* can silently not happen and has to be checked against the filesystem (issue #10 territory). A delegated *read* can quietly summarise away the one paragraph that mattered and has to be checked against citations. Same models, different failure to defend against — which is the honest reason not to merge them.

quorum-review moves from "the other shape" to "the third shape".

## Notes

- README only, +4/−2, branched from `master`.
- Raised from a separate worktree so the in-flight branches (#54, #53) were never touched.
