### PR TITLE
feat(hooks): recognize Chinese keywords in the delegation nudge

### DIFF
--- a/hooks/nudge-delegation.sh
+++ b/hooks/nudge-delegation.sh
@@ -8,7 +8,7 @@
 # never fires the wrapper itself: full automation is a measured net loss below
 # the break-even, so the break-even call must remain a per-task judgment.
 #
-# Heuristic is deliberately conservative (volume/fan-out phrases, EN + JA), and
+# Heuristic is deliberately conservative (volume/fan-out phrases, EN + JA + ZH), and
 # the nudge text is a FIXED string — the user's prompt is never echoed back into
 # the context (no escaping/injection surface).
 #
@@ -39,7 +39,11 @@ case "$PROMPT" in
   *"all files"*|*"every file"*|*"across the codebase"*|*"entire codebase"*|*"whole repo"*| \
   *migrate*|*migration*|*"generate tests"*|*"test coverage"*|*"exhaustive test"*| \
   *scaffold*|*boilerplate*|*"deep research"*|*"web search"*| \
-  *一括*|*全ファイル*|*すべてのファイル*|*網羅*|*移行*|*大量*|*横断*|*リポジトリ全体*)
+  *一括*|*全ファイル*|*すべてのファイル*|*網羅*|*移行*|*大量*|*横断*|*リポジトリ全体*| \
+  *批量*|*全量*|*所有文件*|*全部文件*|*整个项目*|*整个仓库*|*整个代码库*| \
+  *迁移*|*生成测试*|*测试覆盖*|*全套测试*|*脚手架*|*深度研究*|*调研*|*联网搜索*|*网页搜索*|*遍历*|*逐一*| \
+  *子代理*|*子agent*|*"子 agent"*|*交叉验证*|*交叉核对*|*双模型*|*第二意见*|*复核*| \
+  *审查*|*代码审查*|*审阅*|*校对*|*并行*|*批量生成*|*通读*)
     HIT=1 ;;
 esac
 shopt -u nocasematch


### PR DESCRIPTION
## What

The `nudge-delegation.sh` UserPromptSubmit hook already nudges toward delegation when a prompt looks like bulk work — but only for **English and Japanese** phrases. This PR adds a conservative set of **Chinese (ZH)** volume/fan-out keywords so Chinese-language prompts get the same advisory nudge.

## Keywords added

- **Bulk/scope**: 批量, 全量, 所有文件, 全部文件, 整个项目, 整个仓库, 整个代码库, 遍历, 逐一
- **Migration**: 迁移
- **Tests**: 生成测试, 测试覆盖, 全套测试
- **Scaffolding**: 脚手架
- **Research/search**: 深度研究, 调研, 联网搜索, 网页搜索, 通读
- **Subagent / cross-model**: 子代理, 子agent, 子 agent, 交叉验证, 交叉核对, 双模型, 第二意见, 复核
- **Review**: 审查, 代码审查, 审阅, 校对
- **Parallel/bulk-gen**: 并行, 批量生成

## Notes

- `nocasematch` is already on, so Latin-letter substrings (e.g. `子agent`) match case-insensitively.
- The space-bearing pattern `*"子 agent"*` is double-quoted — matching the existing `*"all files"*` convention — because an unquoted space would break the bash `case` word-splitting.
- Matches are advisory only; the delegation decision stays with Claude, unchanged.
- The header comment was updated (`EN + JA` → `EN + JA + ZH`).

## Verification

Tested locally via simulated `UserPromptSubmit` payloads:
- ✅ Chinese bulk prompts trigger (`迁移`, `整个代码库`, `交叉验证`, `子代理`, `审查` …)
- ✅ Small / judgement-heavy Chinese prompts stay silent
- ✅ Explicit `agy-delegate` prompts stay silent (no double-nudge)
- ✅ Existing EN + JA matches unaffected (`migrate every file`, `一括`, …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)