### PR TITLE
fix: --sandbox is not containment — measured, and four docs said it was

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "antigravity",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the SDLC. Claude conducts — requirements, architecture, the hard 20%, verification, review — and routes deterministic, high-volume work (scaffolding, tests, first-pass review, migrations, web/Vertex AI Search) to Antigravity. Hybrid agentic engineering; lower token cost as a financial lever.",
   "author": {
     "name": "linyuting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The `--sandbox` follow-up 0.25.0 deferred, now that agy runs again — and the a
   message says that now.
 - Two guards, both mutation-verified: no user-facing file may recommend `--sandbox` as
   containment, and the media warning must say the grant covers the machine.
-  **The containment rule needed three shapes, each killed by a real mutation.** Matching
+  **The containment rule needed five shapes; four were killed by a mutation, not by reading.** Matching
   per line exempted any line containing "is not" — and the measurement sentence pasted
   after the claim says "it is not those", so re-adding "adds containment" passed. Per line
   with the negation required *adjacent* to the word fixed that and then missed a claim
@@ -37,7 +37,10 @@ The `--sandbox` follow-up 0.25.0 deferred, now that agy runs again — and the a
   passes run and neither subsumes the other. The negation also accepts contractions:
   requiring the literal word would have flagged "`--sandbox` doesn't contain the agent",
   a *correct* sentence, which is the opposite failure and the one that gets a checker
-  deleted. All six shapes are pinned by the checker's own tests — and the contraction case
+  deleted. It does NOT catch a claim spread over three or more sentences, and that is left
+  alone on purpose: a window of N is beatable at N+1, so widening is a race the checker
+  cannot win, and each widening adds false-positive surface. It guards against drift; it
+  is not a proof. All six shapes are pinned by the checker's own tests — and the contraction case
   had to be rewritten, because its first version said "does not contain anything; it
   doesn't contain the agent", where the bare "not" matched first and the case passed with
   contraction support deleted outright. Both reviewers caught that independently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@ The `--sandbox` follow-up 0.25.0 deferred, now that agy runs again — and the a
   passes run and neither subsumes the other. The negation also accepts contractions:
   requiring the literal word would have flagged "`--sandbox` doesn't contain the agent",
   a *correct* sentence, which is the opposite failure and the one that gets a checker
-  deleted. All six shapes are pinned by the checker's own tests.
+  deleted. All six shapes are pinned by the checker's own tests — and the contraction case
+  had to be rewritten, because its first version said "does not contain anything; it
+  doesn't contain the agent", where the bare "not" matched first and the case passed with
+  contraction support deleted outright. Both reviewers caught that independently.
 - The comments in `agy-media.sh` and the test block still framed the exposure as the
   containing directory, directly above the new text saying the opposite, and `SKILL.md`'s
   recipes still passed `--yolo --sandbox` — teaching a flag the same file had just called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,19 @@ The `--sandbox` follow-up 0.25.0 deferred, now that agy runs again — and the a
   split across a wrap, which is how prose is written. Two-line windows fixed the wrap and
   then exempted a bad sentence sitting beside a good one, because the neighbour's negation
   satisfied the whole window. `tests/check-sandbox-claims.py` judges **sentences**, so each
-  claim carries its own negation or none, and it has its own tests for all three shapes.
+  claim carries its own negation or none — and adjacent PAIRS are judged too, after a
+  fourth mutation showed a claim can be spread across two sentences ("Add `--sandbox` for
+  isolation. It contains the untrusted commands."), which neither half trips alone. Both
+  passes run and neither subsumes the other. The negation also accepts contractions:
+  requiring the literal word would have flagged "`--sandbox` doesn't contain the agent",
+  a *correct* sentence, which is the opposite failure and the one that gets a checker
+  deleted. All six shapes are pinned by the checker's own tests.
 - The comments in `agy-media.sh` and the test block still framed the exposure as the
   containing directory, directly above the new text saying the opposite, and `SKILL.md`'s
   recipes still passed `--yolo --sandbox` — teaching a flag the same file had just called
   useless. Both found in review.
 
-298 -> 303.
+298 -> 305.
 
 ## 0.25.0 — security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## 0.25.1
+
+The `--sandbox` follow-up 0.25.0 deferred, now that agy runs again — and the answer is no.
+
+- **`--sandbox` is not containment, and four documents were recommending it as such.**
+  0.25.0 held it back because agy was failing every run with an eligibility error and this
+  repository does not ship behavioural changes it cannot measure. Measured now, on macOS
+  with agy 1.1.19: **with `--yolo`, the flag changes nothing.** A write to an absolute path
+  *outside* `--dir` succeeded (rc 0, 8 bytes, verified by content), `id` ran and returned a
+  real uid, and `curl https://example.com` returned 200 — identical with and without it.
+  agy's own `--help` says "terminal restrictions"; whatever it restricts, it is not those,
+  not in this combination. Not tested on Linux, and the claim is scoped to what was run.
+  Withholding it in 0.25.0 turned out to be the right call for the wrong reason: it would
+  have been a flag that reads as containment and provides none, which is the exact shape
+  this repository keeps having to remove.
+- **The warning 0.25.0 added to `agy-media` understated the exposure.** It said `--dir`
+  exposes the containing directory. The same measurement shows `--dir` is not a boundary —
+  it is where agy starts looking. `--yolo` is a grant over the **whole machine**, and the
+  message says that now.
+- Two guards, both mutation-verified: no user-facing file may recommend `--sandbox` as
+  containment, and the media warning must say the grant covers the machine. The first
+  guard's initial version exempted any line containing "is not" — and the measurement
+  sentence pasted after the claim says "it is not those", so re-adding "adds containment"
+  passed it. The negation now has to sit next to the word.
+
+298 -> 299.
+
 ## 0.25.0 — security
 
 Fixes **GHSA-hwv2-vjgj-8rcv** (CVSS 8.6), reported privately by @Valkyness with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,21 @@ The `--sandbox` follow-up 0.25.0 deferred, now that agy runs again — and the a
   it is where agy starts looking. `--yolo` is a grant over the **whole machine**, and the
   message says that now.
 - Two guards, both mutation-verified: no user-facing file may recommend `--sandbox` as
-  containment, and the media warning must say the grant covers the machine. The first
-  guard's initial version exempted any line containing "is not" — and the measurement
-  sentence pasted after the claim says "it is not those", so re-adding "adds containment"
-  passed it. The negation now has to sit next to the word.
+  containment, and the media warning must say the grant covers the machine.
+  **The containment rule needed three shapes, each killed by a real mutation.** Matching
+  per line exempted any line containing "is not" — and the measurement sentence pasted
+  after the claim says "it is not those", so re-adding "adds containment" passed. Per line
+  with the negation required *adjacent* to the word fixed that and then missed a claim
+  split across a wrap, which is how prose is written. Two-line windows fixed the wrap and
+  then exempted a bad sentence sitting beside a good one, because the neighbour's negation
+  satisfied the whole window. `tests/check-sandbox-claims.py` judges **sentences**, so each
+  claim carries its own negation or none, and it has its own tests for all three shapes.
+- The comments in `agy-media.sh` and the test block still framed the exposure as the
+  containing directory, directly above the new text saying the opposite, and `SKILL.md`'s
+  recipes still passed `--yolo --sandbox` — teaching a flag the same file had just called
+  useless. Both found in review.
 
-298 -> 299.
+298 -> 303.
 
 ## 0.25.0 — security
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,9 @@ Delegation doesn't save money by itself — these do (also in the skill):
 
 **Guardrails**
 - Always **verify** agy's output (it can be wrong, and may even alter its environment to make a check pass — re-run gates yourself in a clean state).
-- `--yolo` auto-approves every tool call — use with `--sandbox` or in a throwaway dir.
+- `--yolo` auto-approves every tool call — a grant over your whole machine, not over `--dir`.
+  **`--sandbox` does not contain it.** Measured on macOS with agy 1.1.19: with `--yolo`, `--sandbox` changed nothing — a write to an absolute path OUTSIDE `--dir` succeeded (rc 0), `id` ran and returned a real uid, and `curl https://example.com` returned 200. agy's own help says "terminal restrictions"; whatever it restricts, it is not those, and not in this combination. Not tested on Linux. Use a throwaway checkout, or a
+  `permissions.allow` rule instead of the flag.
 - Write tasks: run on a dedicated branch/worktree, review the diff before merging.
 
 **Known limits (agy v1.0.x)**

--- a/agents/antigravity-delegate.md
+++ b/agents/antigravity-delegate.md
@@ -64,7 +64,9 @@ agy-delegate [options] "<task>"
 
 Options: `--tier flash|flash-lo|pro` · `--dir <repo-root>` (so agy reads
 `AGENTS.md` + the real files — always prefer this over pasting code) · `--yolo`
-(required for any tool use or file writing in headless mode) · `--sandbox` ·
+(required for any tool use or file writing in headless mode — a grant over the machine,
+not over `--dir`) · `--sandbox` (does NOT contain anything; measured inert under
+`--yolo`) ·
 `--timeout 10m` · `-c`/`--continue` to hold state on the cheap side.
 
 ## Cost discipline (why this subagent exists)

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -21,7 +21,8 @@ Do this:
    describes / scratch-diverts / soft-denies / fails outright depending on version; issue #10). `--mode
    accept-edits` is not a grant either: measured on agy 1.1.13, where the flag is applied
    at all, the write is denied exactly like one without it. Run
-   write tasks on a dedicated branch (+ `--sandbox`), and
+   write tasks on a dedicated branch — `--sandbox` is not containment, it was measured
+   doing nothing under `--yolo` — and
    **verify files actually changed** with `git status`. Claude Code may prompt for or block
    `--dangerously-skip-permissions` — approve it or pre-allow it; non-interactive
    (`claude -p`) without that permission can't write/use-tools via agy. (If the wrapper

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -127,7 +127,7 @@ whether the run admits it ([#10](https://github.com/yuting0624/antigravity-for-c
   Search / terminal when no rule covers them. (`--mode accept-edits` is NOT a headless write grant. Measured on agy 1.1.13 — where the flag is actually applied, since 1.1.12 fixed `--mode` being ignored in headless `-p` entirely — the write is denied exactly like one without it. Earlier notes here said "soft-denied on 1.1.3"; on a build where the flag was never applied, that observation could not tell a denial apart from the flag doing nothing.)
 - Claude Code may prompt for (or in auto-mode, block) `--dangerously-skip-permissions` —
   approve it, or pre-allow `Bash(agy-delegate*)` in your permission settings.
-- Run write tasks on a **dedicated branch** (add `--sandbox` for containment).
+- Run write tasks on a **dedicated branch**. `--sandbox` is *not* containment: Measured on macOS with agy 1.1.19: with `--yolo`, `--sandbox` changed nothing — a write to an absolute path OUTSIDE `--dir` succeeded (rc 0), `id` ran and returned a real uid, and `curl https://example.com` returned 200. agy's own help says "terminal restrictions"; whatever it restricts, it is not those, and not in this combination. Not tested on Linux.
 - **Always verify files actually changed in your workspace** (`git status`) — never trust
   the self-report. The wrapper maps BOTH denial shapes — the 1.1.3 soft-deny and the
   1.1.13 hard error — to **exit 15**, so you get an actionable message instead of a

--- a/scripts/agy-media.sh
+++ b/scripts/agy-media.sh
@@ -164,10 +164,11 @@ Transcript file: $OUT"
 # --yolo: agy needs tool permission to read the media file and write the transcript.
 #
 # Say what that costs, every time. GHSA-hwv2-vjgj-8rcv named this as a contributing
-# factor: --yolo approves ALL tools, including terminal, and --dir hands over the media
-# file's whole CONTAINING directory — so picking one file exposes everything beside it.
-# That is not obvious from "transcribe this recording", and the person choosing the file
-# is the only one who can judge what else is in there.
+# factor and framed it as the containing directory — "picking one file exposes everything
+# beside it". Measured, that is too small: --dir is where agy starts looking, not a
+# boundary, and under --yolo it writes outside it. The grant is over the machine. None of
+# that is obvious from "transcribe this recording", and the person choosing the file is
+# the only one who can judge what is reachable from here.
 #
 # --sandbox was the candidate narrowing in 0.25.0 and it is NOT coming. It was deferred
 # there because agy could not run; now it can, and the measurement says it does nothing:

--- a/scripts/agy-media.sh
+++ b/scripts/agy-media.sh
@@ -169,13 +169,17 @@ Transcript file: $OUT"
 # That is not obvious from "transcribe this recording", and the person choosing the file
 # is the only one who can judge what else is in there.
 #
-# --sandbox is the candidate narrowing (it restricts the terminal tool, which is the bulk
-# of what --yolo grants, and the transcript is written by the file tool). It is NOT
-# applied here because it could not be verified: agy on this account currently fails every
-# run with "Eligibility check failed", so a behavioural change to a working feature would
-# ship untested. Warn now, narrow when it can be measured.
+# --sandbox was the candidate narrowing in 0.25.0 and it is NOT coming. It was deferred
+# there because agy could not run; now it can, and the measurement says it does nothing:
+# with --yolo, a write to an absolute path OUTSIDE --dir succeeded, `id` ran, and curl
+# reached the network — identical with and without the flag. Adding it would have shipped
+# something that reads as containment and provides none.
+#
+# The same measurement corrected this warning. 0.25.0 said "--dir exposes $DIR", which
+# UNDERSTATES it: --dir is where agy looks first, not a boundary. --yolo approves every
+# tool, and agy then writes wherever it likes.
 NEIGHBOURS="$(ls -1 "$DIR" 2>/dev/null | grep -c . || echo 0)"
-echo "agy-media: --yolo approves ALL agy tools (including terminal) and --dir exposes $DIR — $NEIGHBOURS entr(y/ies) beside your file — for this run. Move the file to a directory of its own if anything there is sensitive." >&2
+echo "agy-media: --yolo approves ALL agy tools for this run, including the terminal, so this is a grant over YOUR WHOLE MACHINE — not just $DIR ($NEIGHBOURS entr(y/ies) beside your file), which is only where agy starts looking. Measured: under --yolo, agy writes outside --dir and runs shell commands, and --sandbox does not change that. Run this on files you are willing to hand an unsupervised agent." >&2
 ARGS=(--tier "$TIER" --yolo --dir "$DIR" --timeout "$TIMEOUT")
 if [ "$PRINT_CMD" -eq 1 ]; then
   { printf 'agy-delegate'; printf ' %q' "${ARGS[@]}" "$PROMPT"; printf '\n'; }

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: antigravity
 description: Run the Antigravity CLI (Gemini) as a collaborating AI inside Claude Code, with intelligent model routing across the software development lifecycle. Claude is the conductor/orchestrator — requirements, architecture, the hard 20%, verification, and review — and routes deterministic, high-volume work (scaffolding, boilerplate, test generation, first-pass review, migrations, web/Vertex AI Search) to Antigravity (Gemini), the cheaper, faster model. Use when the user wants to "use Antigravity / agy", "vibe code / agentic engineering", "accelerate the SDLC", "delegate to Gemini", "scaffold / generate tests / migrate", "first-pass code review", "search web or internal/company data", "deep research / multi-source research report", "second-model cross-check", or "lower token cost on a big job". Claude always verifies Antigravity's output and re-checks itself if unsatisfied.
-version: 0.25.0
+version: 0.25.1
 ---
 
 # Antigravity for Claude Code — hybrid SDLC
@@ -237,7 +237,8 @@ commands** (`--yolo` grants write + terminal):
   `git status` (the wrapper maps BOTH denial shapes — 1.1.3's soft deny and 1.1.13's
   hard error — to exit `15`, so you're not left guessing).
 - Run it on a **dedicated git branch or worktree** so changes are isolated.
-- Add `--sandbox` for execution containment.
+- `--sandbox` is NOT execution containment. Measured on macOS with agy 1.1.19: with `--yolo`, `--sandbox` changed nothing — a write to an absolute path OUTSIDE `--dir` succeeded (rc 0), `id` ran and returned a real uid, and `curl https://example.com` returned 200. agy's own help says "terminal restrictions"; whatever it restricts, it is not those, and not in this combination. Not tested on Linux. Contain by what you check
+  out and by `permissions.allow`, not by the flag.
 - **Claude reviews the diff before merging** — never auto-merge agy's writes.
 
 ## Cost discipline — where the savings actually come from

--- a/skills/antigravity/SKILL.md
+++ b/skills/antigravity/SKILL.md
@@ -341,7 +341,7 @@ any figure.
 ROOT=agy-delegate
 
 # Scaffold from a spec (Claude wrote the spec/architecture)
-"$ROOT" --tier pro --yolo --sandbox --dir ./app \
+"$ROOT" --tier pro --yolo --dir ./app \
   "Scaffold per ARCHITECTURE.md: dirs, configs, stub modules. Follow AGENTS.md."
 
 # Generate tests for a contract Claude defined
@@ -352,11 +352,11 @@ ROOT=agy-delegate
 "$ROOT" --tier pro "Review for bugs/security/perf, be skeptical. List file:line: <diff>"
 
 # Implement-until-tests-pass (feedback loop; isolate on a branch)
-"$ROOT" --tier pro --yolo --sandbox --dir ./app \
+"$ROOT" --tier pro --yolo --dir ./app \
   "Implement feature X to satisfy AGENTS.md and make 'pytest -q' pass. Iterate until green."
 
 # Migration / modernization
-"$ROOT" --tier pro --yolo --sandbox --dir ./svc \
+"$ROOT" --tier pro --yolo --dir ./svc \
   "Migrate all callers from APIv1 to APIv2 per MIGRATION.md. List every file changed."
 
 # Web search → Claude re-checks

--- a/tests/check-sandbox-claims.py
+++ b/tests/check-sandbox-claims.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Fail when a file tells the reader that `--sandbox` contains the agent.
+
+It does not. Measured on macOS with agy 1.1.19: under `--yolo`, a write to an absolute
+path outside `--dir` succeeded, `id` ran and returned a real uid, and curl reached the
+network — identical with and without the flag. Four documents were recommending it "for
+containment" when 0.25.1 went to look.
+
+This is a security claim, which is why it gets a checker rather than a habit. Telling
+someone a flag confines an agent that it does not confine is the worst direction for a
+documentation error to fail in.
+
+SENTENCES, not lines and not two-line windows, because both of those were tried:
+
+  * per line missed a claim split across a wrap, which is how prose is written;
+  * two-line windows fixed that and then exempted a bad sentence sitting next to a good
+    one — the negation from the neighbour satisfied the whole window.
+
+Splitting on sentence boundaries after joining the lines handles both: each claim is
+judged with its own negation or without one.
+"""
+import re
+import sys
+
+# The claim and its negation, e.g. "--sandbox is not containment", "does not contain".
+# The negation has to sit next to the word: an "is not" elsewhere in the sentence is
+# about something else, and letting it exempt the sentence is how the first version of
+# this rule passed a re-added "adds containment".
+NEGATED = re.compile(r"\bnot\b[^.]{0,20}contain", re.I)
+SANDBOX = re.compile(r"sandbox", re.I)
+CONTAIN = re.compile(r"contain", re.I)
+
+
+def sentences(text):
+    """Join wrapped lines, then split on sentence ends, keeping a line number."""
+    out, buf, start = [], [], 1
+    for n, line in enumerate(text.split("\n"), 1):
+        if not line.strip():
+            if buf:
+                out.append((start, " ".join(buf)))
+                buf = []
+            continue
+        if not buf:
+            start = n
+        buf.append(line.strip())
+    if buf:
+        out.append((start, " ".join(buf)))
+
+    split = []
+    for line_no, para in out:
+        for part in re.split(r"(?<=[.!?])\s+", para):
+            if part.strip():
+                split.append((line_no, part.strip()))
+    return split
+
+
+def problems(path):
+    text = open(path).read()
+    bad = []
+    for line_no, sent in sentences(text):
+        if SANDBOX.search(sent) and CONTAIN.search(sent) and not NEGATED.search(sent):
+            bad.append((path, line_no, sent[:110]))
+    return bad
+
+
+if __name__ == "__main__":
+    found = []
+    for p in sys.argv[1:]:
+        try:
+            found += problems(p)
+        except OSError:
+            continue
+    for path, line_no, sent in found:
+        print("%s:~%d: describes --sandbox as containment — it is not: %s" % (path, line_no, sent))
+    sys.exit(1 if found else 0)

--- a/tests/check-sandbox-claims.py
+++ b/tests/check-sandbox-claims.py
@@ -10,14 +10,21 @@ This is a security claim, which is why it gets a checker rather than a habit. Te
 someone a flag confines an agent that it does not confine is the worst direction for a
 documentation error to fail in.
 
-SENTENCES, not lines and not two-line windows, because both of those were tried:
+SENTENCES, after joining wrapped lines — and adjacent sentence PAIRS as well. Four rules
+were tried and each of the first three was killed by a mutation, not by reading:
 
-  * per line missed a claim split across a wrap, which is how prose is written;
-  * two-line windows fixed that and then exempted a bad sentence sitting next to a good
-    one — the negation from the neighbour satisfied the whole window.
+  * per line, negation anywhere on it: the measurement text pasted after a claim says
+    "it is not those", which exempted a re-added "adds containment";
+  * per line, negation adjacent to the word: missed a claim split across a wrap, which
+    is how prose is written;
+  * two-line windows: caught the wrap, then exempted a bad sentence sitting beside a
+    good one, because the neighbour's negation satisfied the whole window;
+  * single sentences: fixed that, and missed a claim spread over two of them — "Add
+    --sandbox for isolation. It contains the untrusted commands."
 
-Splitting on sentence boundaries after joining the lines handles both: each claim is
-judged with its own negation or without one.
+So both passes run. A sentence is judged with its own negation or none, and each
+adjacent pair is judged too. Either firing is enough. Neither subsumes the other: pairs
+alone re-admit the beside-a-good-one bug, sentences alone miss the split claim.
 """
 import re
 import sys
@@ -26,7 +33,10 @@ import sys
 # The negation has to sit next to the word: an "is not" elsewhere in the sentence is
 # about something else, and letting it exempt the sentence is how the first version of
 # this rule passed a re-added "adds containment".
-NEGATED = re.compile(r"\bnot\b[^.]{0,20}contain", re.I)
+# Contractions count. Requiring the literal word would flag "--sandbox doesn't contain
+# the agent" — a correct sentence — which is the opposite failure and the one that makes
+# a checker get deleted. Reviewers caught it.
+NEGATED = re.compile(r"(?:\bnot\b|n't|\bnever\b)[^.]{0,20}contain", re.I)
 SANDBOX = re.compile(r"sandbox", re.I)
 CONTAIN = re.compile(r"contain", re.I)
 
@@ -54,12 +64,34 @@ def sentences(text):
     return split
 
 
+def claims(sent):
+    """True when this text asserts containment without negating it."""
+    return bool(SANDBOX.search(sent) and CONTAIN.search(sent) and not NEGATED.search(sent))
+
+
 def problems(path):
-    text = open(path).read()
-    bad = []
-    for line_no, sent in sentences(text):
-        if SANDBOX.search(sent) and CONTAIN.search(sent) and not NEGATED.search(sent):
-            bad.append((path, line_no, sent[:110]))
+    """Single sentences AND adjacent pairs. The two catch different shapes and neither
+    subsumes the other, so both run and either one is enough to flag.
+
+    A pair alone re-admits the bug the sentence split fixed — a bad sentence beside a
+    good one, exempted by the neighbour's negation. A sentence alone misses a claim
+    spread over two of them ("Add --sandbox for isolation. It contains the commands."),
+    which is what review found here. Running both costs one extra pass.
+    """
+    sents = sentences(open(path).read())
+    bad, seen = [], set()
+
+    def add(line_no, text):
+        if line_no not in seen:
+            seen.add(line_no)
+            bad.append((path, line_no, text[:110]))
+
+    for line_no, sent in sents:
+        if claims(sent):
+            add(line_no, sent)
+    for (line_no, a), (_, b) in zip(sents, sents[1:]):
+        if claims(a + " " + b):
+            add(line_no, (a + " " + b))
     return bad
 
 

--- a/tests/check-sandbox-claims.py
+++ b/tests/check-sandbox-claims.py
@@ -25,6 +25,12 @@ were tried and each of the first three was killed by a mutation, not by reading:
 So both passes run. A sentence is judged with its own negation or none, and each
 adjacent pair is judged too. Either firing is enough. Neither subsumes the other: pairs
 alone re-admit the beside-a-good-one bug, sentences alone miss the split claim.
+
+WHAT IT DOES NOT CATCH, deliberately: a claim spread across THREE or more sentences.
+A window of N is always beatable at N+1, so widening it is a race the checker cannot
+win, and each widening costs a false-positive surface — the pair pass already had to be
+paired with the single pass to avoid one. This is a guard against drift, not a proof.
+Read the prose when you change it.
 """
 import re
 import sys

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -845,6 +845,27 @@ out=$(env -u CLAUDE_PLUGIN_ROOT "$BIN/measure-session" 2>&1 | head -1)
 case "$out" in *measure-session*) echo "ok: bin/measure-session forwards to the .py"; PASS=$((PASS+1));;
   *) echo "FAIL: bin/measure-session did not forward (got: '$out')"; FAIL=$((FAIL+1));; esac
 
+echo "== --sandbox is not sold as containment =="
+# 0.25.0 deferred adding --sandbox to agy-media because agy could not run. It runs now,
+# and the measurement killed the idea: under --yolo a write to an absolute path OUTSIDE
+# --dir succeeded, `id` ran, curl reached the network — identical with and without the
+# flag. Four documents were recommending it "for containment", which is the shape this
+# repo keeps having to remove: a guard that reads as protection and provides none.
+#
+# The negation must sit NEXT TO the word, not anywhere on the line. The first version
+# exempted any line containing "is not", and the measurement sentence pasted after the
+# claim says "it is not those" — so re-adding "adds containment" passed the guard.
+sb_bad=""
+for f in README.md docs/*.md skills/*/SKILL.md agents/*.md commands/*.md scripts/*.sh hooks/*.sh; do
+  [ -f "$ROOT/$f" ] || continue
+  hit="$(grep -niE 'sandbox' "$ROOT/$f" | grep -iE 'contain' \
+         | grep -viE 'not[^.]{0,20}contain' | cut -d: -f1 | tr '\n' ',')"
+  [ -n "$hit" ] && sb_bad="$sb_bad $f:${hit%,}"
+done
+if [ -z "$sb_bad" ]; then
+  echo "ok: nothing recommends --sandbox as containment"; PASS=$((PASS+1));
+else echo "FAIL: --sandbox described as containment at:$sb_bad"; FAIL=$((FAIL+1)); fi
+
 echo "== agy-media says what --yolo --dir exposes =="
 # GHSA-hwv2-vjgj-8rcv listed this as a contributing factor: --yolo approves ALL tools and
 # --dir hands over the media file's whole containing directory, which "transcribe this
@@ -852,9 +873,12 @@ echo "== agy-media says what --yolo --dir exposes =="
 mdir="$TMP/mediawarn"; rm -rf "$mdir"; mkdir -p "$mdir"
 : > "$mdir/clip.wav"; : > "$mdir/tax-return.pdf"
 media_out="$(bash "$ROOT/scripts/agy-media.sh" --print-command "$mdir/clip.wav" 2>&1 >/dev/null)"
-if has 'approves ALL agy tools' "$media_out" && has "$mdir" "$media_out"; then
-  echo "ok: agy-media names the directory --dir exposes"; PASS=$((PASS+1));
-else echo "FAIL: agy-media does not say what --yolo --dir exposes"; FAIL=$((FAIL+1)); fi
+# It must say the grant is over the MACHINE. 0.25.0's version said "--dir exposes $DIR",
+# which understates it — --dir is where agy starts looking, not a boundary, and that was
+# measured: under --yolo agy writes outside it.
+if has 'WHOLE MACHINE' "$media_out" && has "$mdir" "$media_out"; then
+  echo "ok: agy-media says the grant covers the machine, not just --dir"; PASS=$((PASS+1));
+else echo "FAIL: agy-media understates --yolo as a --dir-scoped exposure"; FAIL=$((FAIL+1)); fi
 
 echo "== doctor.sh tier-model check (agy 1.1.5 slug format) =="
 # The stub's `agy models` emits slugs (gemini-3.5-flash); doctor's default tier models are

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -852,24 +852,33 @@ echo "== --sandbox is not sold as containment =="
 # flag. Four documents were recommending it "for containment", which is the shape this
 # repo keeps having to remove: a guard that reads as protection and provides none.
 #
-# The negation must sit NEXT TO the word, not anywhere on the line. The first version
-# exempted any line containing "is not", and the measurement sentence pasted after the
-# claim says "it is not those" — so re-adding "adds containment" passed the guard.
-sb_bad=""
-for f in README.md docs/*.md skills/*/SKILL.md agents/*.md commands/*.md scripts/*.sh hooks/*.sh; do
-  [ -f "$ROOT/$f" ] || continue
-  hit="$(grep -niE 'sandbox' "$ROOT/$f" | grep -iE 'contain' \
-         | grep -viE 'not[^.]{0,20}contain' | cut -d: -f1 | tr '\n' ',')"
-  [ -n "$hit" ] && sb_bad="$sb_bad $f:${hit%,}"
-done
-if [ -z "$sb_bad" ]; then
+# The rule went through three shapes before it worked, each failing a real mutation:
+# per line missed a claim split across a wrap; two-line windows fixed that and then
+# exempted a bad sentence sitting beside a good one, because the neighbour's negation
+# satisfied the window. check-sandbox-claims.py judges SENTENCES, so each claim carries
+# its own negation or none.
+if python3 "$HERE/check-sandbox-claims.py" "$ROOT"/README.md "$ROOT"/docs/*.md \
+     "$ROOT"/skills/*/SKILL.md "$ROOT"/agents/*.md "$ROOT"/commands/*.md \
+     "$ROOT"/scripts/*.sh "$ROOT"/hooks/*.sh; then
   echo "ok: nothing recommends --sandbox as containment"; PASS=$((PASS+1));
-else echo "FAIL: --sandbox described as containment at:$sb_bad"; FAIL=$((FAIL+1)); fi
+else echo "FAIL: --sandbox described as containment (see above)"; FAIL=$((FAIL+1)); fi
+# The checker is itself the guard, so a shape it misses is a silent pass. All three that
+# bit the inline versions are pinned, plus the negated form that must stay clean.
+sbc_case() { # $1 = label, $2 = expected rc, $3 = file body
+  local f="$TMP/sbc-$1.md"; printf '%b\n' "$3" > "$f"
+  python3 "$HERE/check-sandbox-claims.py" "$f" >/dev/null 2>&1; local rc=$?
+  if [ "$rc" = "$2" ]; then echo "ok: sandbox-claim checker — $1"; PASS=$((PASS+1));
+  else echo "FAIL: sandbox-claim checker — $1 (rc=$rc, want $2)"; FAIL=$((FAIL+1)); fi
+}
+sbc_case one-line   1 'Run on a branch. Add `--sandbox` for real containment of the agent.'
+sbc_case wrapped    1 'Run on a branch. Add `--sandbox` for real\ncontainment of the agent.'
+sbc_case beside-ok  1 '`--sandbox` is *not* containment: measured.\nAdd `--sandbox` for real containment.'
+sbc_case negated    0 'The `--sandbox` flag is not containment. It was measured and it is not those.'
 
 echo "== agy-media says what --yolo --dir exposes =="
-# GHSA-hwv2-vjgj-8rcv listed this as a contributing factor: --yolo approves ALL tools and
-# --dir hands over the media file's whole containing directory, which "transcribe this
-# recording" does not suggest. --print-command stops before any delegation runs.
+# GHSA-hwv2-vjgj-8rcv listed this as a contributing factor and scoped it to the containing
+# directory. Measured, the grant is wider than that — --dir is not a boundary — which is
+# what the assertion below pins. --print-command stops before any delegation runs.
 mdir="$TMP/mediawarn"; rm -rf "$mdir"; mkdir -p "$mdir"
 : > "$mdir/clip.wav"; : > "$mdir/tax-return.pdf"
 media_out="$(bash "$ROOT/scripts/agy-media.sh" --print-command "$mdir/clip.wav" 2>&1 >/dev/null)"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -873,7 +873,11 @@ sbc_case() { # $1 = label, $2 = expected rc, $3 = file body
 sbc_case one-line   1 'Run on a branch. Add `--sandbox` for real containment of the agent.'
 sbc_case wrapped    1 'Run on a branch. Add `--sandbox` for real\ncontainment of the agent.'
 sbc_case beside-ok  1 '`--sandbox` is *not* containment: measured.\nAdd `--sandbox` for real containment.'
+sbc_case split-pair 1 'Add `--sandbox` for isolation. It contains the untrusted commands.'
 sbc_case negated    0 'The `--sandbox` flag is not containment. It was measured and it is not those.'
+# A contraction is still a negation. Requiring the literal word would flag a CORRECT
+# sentence, which is the opposite failure and the one that gets a checker deleted.
+sbc_case contracted 0 'The `--sandbox` flag does not contain anything; it doesn'"'"'t contain the agent.'
 
 echo "== agy-media says what --yolo --dir exposes =="
 # GHSA-hwv2-vjgj-8rcv listed this as a contributing factor and scoped it to the containing

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -877,7 +877,12 @@ sbc_case split-pair 1 'Add `--sandbox` for isolation. It contains the untrusted 
 sbc_case negated    0 'The `--sandbox` flag is not containment. It was measured and it is not those.'
 # A contraction is still a negation. Requiring the literal word would flag a CORRECT
 # sentence, which is the opposite failure and the one that gets a checker deleted.
-sbc_case contracted 0 'The `--sandbox` flag does not contain anything; it doesn'"'"'t contain the agent.'
+#
+# ONLY the contraction — no bare "not" or "never" anywhere in it. The first version of
+# this case read "does not contain anything; it doesn't contain the agent", where the
+# earlier bare "not" matched first and the case passed with contraction support deleted
+# outright. Both reviewers caught that independently.
+sbc_case contracted 0 'The `--sandbox` flag doesn'"'"'t contain the agent.'
 
 echo "== agy-media says what --yolo --dir exposes =="
 # GHSA-hwv2-vjgj-8rcv listed this as a contributing factor and scoped it to the containing


### PR DESCRIPTION
The `--sandbox` follow-up [0.25.0](https://github.com/yuting0624/antigravity-for-claude-code/releases/tag/v0.25.0) deferred. agy runs again, so it could be measured. **The answer is no.**

## The measurement

macOS, agy 1.1.19, `agy-delegate --tier flash-lo --yolo [--sandbox] --dir $IN`:

| | with `--sandbox` | without |
|---|---|---|
| write to an absolute path **outside** `--dir` | rc 0, file written, content verified | rc 0, written |
| `id` via the terminal tool | ran, returned a real uid | ran |
| `curl https://example.com` | **200** | 200 |

Identical. agy's own `--help` says *"Run in a sandbox with terminal restrictions enabled"* — whatever it restricts, it is not those, and not in combination with `--yolo`, which is the only combination this plugin ships. Not tested on Linux; the claim is scoped to what was actually run.

**Holding it back in 0.25.0 was right for the wrong reason.** It was deferred because agy could not run at all, not because it was suspected of being inert. Adding it would have shipped a flag that reads as containment and provides none — the exact shape this repository keeps having to remove.

## What changes

**Four documents recommended it for containment** — README, TROUBLESHOOTING, SKILL.md, `commands/delegate.md`. Retracted, each carrying the measurement.

**The warning 0.25.0 added to `agy-media` understated the exposure.** It said `--dir` exposes the containing directory. The same measurement shows `--dir` is not a boundary — it is where agy *starts looking*. `--yolo` is a grant over the whole machine, and the message says that now:

> `--yolo` approves ALL agy tools for this run, including the terminal, so this is a grant over YOUR WHOLE MACHINE — not just `<dir>` … which is only where agy starts looking.

This matters beyond wording: GHSA-hwv2-vjgj-8rcv treated the `agy-media` exposure as *"picking one media file exposes its whole containing directory"*. That was the advisory's framing and mine, and it is too small.

## Tests

**305**, up 7, plus a rewritten assertion. Both guards mutation-verified.

The sandbox rule needed **five** shapes, each killed by a mutation rather than by reading — see the CHANGELOG. The **first version did not work**: it exempted any line containing `is not`, and the measurement sentence pasted after the claim says *"it is not those"* — so re-adding "adds containment" passed it. The negation has to sit next to the word. Caught by mutating the fix back, not by reading it.