### PR TITLE
test: beside-ok's comment described a guard it does not provide

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -872,6 +872,11 @@ sbc_case() { # $1 = label, $2 = expected rc, $3 = file body
 }
 sbc_case one-line   1 'Run on a branch. Add `--sandbox` for real containment of the agent.'
 sbc_case wrapped    1 'Run on a branch. Add `--sandbox` for real\ncontainment of the agent.'
+# beside-ok pins the SINGLE-sentence pass: a good neighbour must not exempt a bad
+# sentence. Note what it does NOT pin — deleting the pair pass leaves it green, because
+# sentence splitting already separates the two claims. The window bug it is named for
+# belonged to the discarded two-LINE implementation. split-pair below is the fixture that
+# actually requires the pair pass. Review caught the comment claiming otherwise.
 sbc_case beside-ok  1 '`--sandbox` is *not* containment: measured.\nAdd `--sandbox` for real containment.'
 sbc_case split-pair 1 'Add `--sandbox` for isolation. It contains the untrusted commands.'
 sbc_case negated    0 'The `--sandbox` flag is not containment. It was measured and it is not those.'


### PR DESCRIPTION
Last finding from the [#63](https://github.com/yuting0624/antigravity-for-claude-code/pull/63) review, which I merged past while running the release. Comment-only.

`beside-ok` is framed as pinning the *"bad sentence beside a good one"* window bug. That bug belonged to the **two-line-window** implementation that was discarded. Under sentence splitting the two claims are already separate, so the fixture stays green with the pair pass deleted outright.

Verified by deleting it:

```
FAIL: sandbox-claim checker — split-pair (rc=0, want 1)
```

Only `split-pair` turns red. So `beside-ok` pins the **single-sentence** pass — a good neighbour must not exempt a bad sentence — and `split-pair` is what requires the pair pass. The comment says both now, including what it does *not* pin.

No behaviour change; 305 tests unchanged. Opened as a PR rather than pushed to master: the v0.25.0 patch went direct and bypassed the repository's "changes must be made through a pull request" rule, which was the right call under an embargo and is not one to repeat without one.