### PR TITLE
fix(delegate): stop the whitespace checks from burning CPU on large outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to **Antigravity for Claude Code**. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are in `.claude-plugin/plugin.json`.
 
+## Unreleased
+
+- **agy-delegate.sh no longer burns a CPU core on large outputs on macOS.** The two
+  whitespace-emptiness checks stripped every whitespace character from the whole output
+  (`${OUT//[...]/}`) just to test if anything was left — on the bash 3.2.57 that macOS
+  ships, that gets drastically slower as output grows (measured: 26.6 s at 8 KB; two real
+  wrappers spun at ~99% CPU for 24 min and 2+ hours after agy had already finished). Both
+  checks are now a glob that stops at the first non-whitespace character, with the same
+  whitespace set and unchanged exit-code behavior (#66).
+
 ## 0.25.1
 
 The `--sandbox` follow-up 0.25.0 deferred, now that agy runs again — and the answer is no.

--- a/scripts/agy-delegate.sh
+++ b/scripts/agy-delegate.sh
@@ -420,7 +420,9 @@ set -e
 # the structured error for classification, and reports token usage on stderr.
 # Any parse failure falls back to treating OUT as plain text (never fatal).
 JSON_STATUS=""; JSON_ERROR=""
-if [ "$JSON_MODE" -eq 1 ] && [ -n "${OUT//[$' \t\n\r']/}" ]; then
+# Glob, not ${OUT//[...]/}: stripping the whole string to test emptiness is minutes-to-
+# hours at tens of KB on macOS /bin/bash 3.2 (n^~2.6); the glob stops at the first hit.
+if [ "$JSON_MODE" -eq 1 ] && [[ "$OUT" = *[!$' \t\n\r']* ]]; then
   # The response can be multi-line, so it goes to a temp file; the single-line
   # metadata comes back on stdout. (Command substitution strips NUL bytes, so a
   # NUL-delimited stream is not an option here.)
@@ -525,7 +527,7 @@ $blob"
   signal AGY_FAILED "agy exited $RC"
   exit 2
 fi
-if [ -z "${OUT//[$' \t\n\r']/}" ]; then
+if [[ "$OUT" != *[!$' \t\n\r']* ]]; then   # same glob as above, not the quadratic strip
   # agy >= 1.1.3 soft-denies a tool needing permission in headless mode and returns
   # rc=0 with EMPTY stdout plus an explanatory stderr notice (the evolved issue #10:
   # earlier versions silently wrote to a scratch dir or only described the edit). Detect


### PR DESCRIPTION
Fixes yuting0624/antigravity-for-claude-code#66.

## What this changes

`agy-delegate.sh` checks "did agy print anything besides whitespace?" by deleting every whitespace character from the whole output and seeing what's left (`${OUT//[$' \t\n\r']/}`, at two sites). That works, but on the bash a Mac ships out of the box (3.2.57, frozen since 2007), the delete gets drastically slower as the output grows: we measured 3.75 s at 4 KB and 26.6 s at 8 KB, and traced two real incidents where the wrapper sat at ~99% CPU for 24 minutes and for 2+ hours *after* agy had already finished. On a modern Linux bash the same line is quick — which is why CI never saw it. The issue has the full story and measurements.

The fix asks the same question with a glob, which stops at the first non-whitespace character instead of rewriting the whole string first:

```bash
[[ "$OUT" = *[!$' \t\n\r']* ]]
```

Same whitespace set as before, so "whitespace-only means empty" — and the exit-3 / permission soft-deny behavior built on it — is unchanged. Worst case is one linear scan (~2 ms on a 61 KB all-whitespace string), the case that previously took hours.

## Checks done

- `bash -n` clean on /bin/bash 3.2.57 (the CONTRIBUTING.md floor)
- `tests/run-tests.sh`: 305 pass, 0 fail with the patch applied
- Old and new tests agree on every probe tried (`\v`, `\f`, newlines, mixed, empty, whitespace-only)
- End-to-end with a stubbed `agy`: normal reply rc 0, empty reply rc 3, whitespace-only rc 3
- shellcheck not run locally (not installed) — relying on the CI gate

## Changelog

Entry added to `CHANGELOG.md` under a new "Unreleased" section, per CONTRIBUTING.md.
