### PR TITLE
test: pin the whitespace-check performance that #67 fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ All notable changes to **Antigravity for Claude Code**. Format loosely follows
   wrappers spun at ~99% CPU for 24 min and 2+ hours after agy had already finished). Both
   checks are now a glob that stops at the first non-whitespace character, with the same
   whitespace set and unchanged exit-code behavior (#66).
+- **The same shape was live in `cloud-debug.sh`, and worse.** Found by review of the fix
+  above, not by the fix. `${LOGS//[[:space:]]/}` decided "did gcloud return any logs?" on
+  the raw `gcloud logging read` output — and the 200 KB cap sits *after* that line, so a
+  chatty service could pin a core before the cap ever ran. Measured on 3.2.57: the POSIX
+  class spelling costs the same as the ANSI-C one (23.8s vs 24.4s at 8 KB), so the first
+  static guard, which matched only the ANSI-C form, reported all-clear over it.
+  A cheap glob now runs first and the strip is reached only when the string is already
+  nothing but whitespace and brackets — exactly equivalent, checked on 19 probes.
+- **Why 305 tests on a bash-3.2 machine saw none of this.** The cost switches on whether
+  there is a *match at all*, not on how many: same 8 KB, 0% whitespace 0.04s, 2% or more
+  21-25s. Both large fixtures in the suite sat on the fast side — the delegate's `big` is
+  solid `x` and `$( )` strips its one trailing newline, and the gcloud `big` mode is solid
+  `A` inside JSON. Neither contained a single space. Both now have whitespace-bearing
+  counterparts, and both new tests kill the run at 30s rather than waiting it out, because
+  bash cannot service SIGTERM inside the substitution: `timeout 90` around the unfixed
+  wrapper returned after 205s, which is also why `agy-job status` kept saying `running`.
 
 ## 0.25.1
 

--- a/scripts/cloud-debug.sh
+++ b/scripts/cloud-debug.sh
@@ -200,11 +200,31 @@ if [ "$RC" -ne 0 ]; then
 fi
 
 # No matching logs is a valid diagnostic result, not an error.
-case "${LOGS//[[:space:]]/}" in
+#
+# The cheap glob runs FIRST. `${LOGS//[[:space:]]/}` rewrites the whole string, and on the
+# bash macOS ships (3.2.57) that is catastrophic past a few KB — measured here, 8 KB took
+# 23.8s and every doubling cost ~6x. $LOGS is raw `gcloud logging read` output and the
+# 200 KB cap below is applied AFTER this point, so a chatty service could pin a core for
+# hours before the cap ever ran. Same shape as issue #66, found by review of the fix for
+# it; the ANSI-C and POSIX-class spellings cost the same.
+#
+# `]` must be the FIRST character in the bracket expression to be literal. Spelled
+# `[![:space:][]]` instead, the `]` closes the expression early and plain text like `x`
+# is misread as "no logs" — measured, before this went in.
+#
+# Exactly equivalent, verified on 19 probes including `[]`, `[ ]`, `[\n]`, `[[]]`, `][`,
+# `]`, real arrays and plain text: anything carrying a character that is neither
+# whitespace nor a bracket is logs, and the strip still decides the rest — on a string
+# that by then contains nothing but whitespace and brackets.
+case "$LOGS" in
+  *[!][:space:][]*) : ;;   # real content: never strip a large string
+  *)
+case "${LOGS//[[:space:]]/}" in   # ws-strip-ok: reached only when $LOGS is ws+brackets
   ''|'[]')
     echo "cloud-debug: no logs at severity>=$SEVERITY for service '$SERVICE'${REGION:+ in $REGION} within --since $SINCE."
     echo "cloud-debug: widen the window (--since), lower --severity, or confirm the service name/region."
     exit 0 ;;
+esac ;;
 esac
 
 # Soft byte cap as a backstop: field projection already trims a lot, but a very

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -147,6 +147,10 @@ if [ "$1" = "logging" ] && [ "$2" = "read" ]; then
     empty) echo "[]" ;;
     fail)  echo "ERROR: (gcloud.logging.read) something broke" >&2; exit 1 ;;
     big)   pad=$(printf 'A%.0s' {1..3000}); printf '[{"m":"%s"}]TAIL_SENTINEL\n' "$pad" ;;  # large ASCII payload w/ tail marker
+    # Large AND whitespace-bearing. `big` above is solid 'A' inside JSON with no space
+    # anywhere, which is the case bash 3.2's substitution handles fast — the same blind
+    # spot the delegate's `big` had. Real log text has spaces in it.
+    bigws) pad=$(printf 'word %.0s' {1..3000}); printf '[{"m":"%s"}]\n' "$pad" ;;
     bigjp) pad=$(printf 'あ%.0s' {1..3000}); printf '[{"m":"%s"}]TAIL_SENTINEL\n' "$pad" ;;  # large multibyte (3-byte/char) payload
     *)     echo '[{"severity":"ERROR","textPayload":"KeyError: DATABASE_URL","timestamp":"2026-06-28T00:00:00Z"}]' ;;
   esac
@@ -866,17 +870,60 @@ echo "== the whitespace check does not pin a CPU (issue #66, bash 3.2) =="
 # The bound is generous on purpose — the fixed path is ~0.9s here and the broken one is
 # minutes, so anything in between separates them. -k forces a KILL so a regression fails
 # in 35s instead of hanging CI for the full 205.
-ws_dir="$TMP/wsbench"; rm -rf "$ws_dir"; mkdir -p "$ws_dir"
+# The bound must NOT depend on GNU `timeout`. Stock macOS does not ship it, and stock
+# macOS is exactly where bash 3.2 lives — so keying on it would make this test skip, or
+# worse report ok on rc=127, on the one platform it exists to protect. Both reviewers
+# caught that. Background the run and kill it from here instead; works everywhere.
+ws_bounded() { # $1 = seconds, rest = command. Echoes the exit status.
+  local secs="$1"; shift
+  "$@" >/dev/null 2>&1 &
+  local pid=$! rc
+  ( sleep "$secs"; kill -9 "$pid" 2>/dev/null ) >/dev/null 2>&1 &
+  local killer=$!
+  wait "$pid"; rc=$?
+  kill "$killer" 2>/dev/null; wait "$killer" 2>/dev/null
+  echo "$rc"
+}
 ws_t0="$(python3 -c 'import time; print(time.time())')"
-STUB_MODE=bigws timeout -k 5 30 "$DELEGATE" "hi" >/dev/null 2>&1; ws_rc=$?
+ws_rc="$(STUB_MODE=bigws ws_bounded 30 "$DELEGATE" "hi")"
 ws_t1="$(python3 -c 'import time; print(time.time())')"
 ws_secs="$(python3 -c "print('%.1f' % ($ws_t1 - $ws_t0))")"
-if [ "$ws_rc" != 124 ] && [ "$ws_rc" != 137 ]; then
+if [ "$ws_rc" = 0 ]; then
   echo "ok: a 17KB whitespace-bearing reply completes (${ws_secs}s)"; PASS=$((PASS+1));
 else echo "FAIL: the whitespace check pinned the CPU on a 17KB reply (rc=$ws_rc after ${ws_secs}s)"; FAIL=$((FAIL+1)); fi
-# ...and the shipped scripts must not reintroduce the shape anywhere else. Scoped to what
-# ships: this file uses it once on a 30-line workflow snippet, where it costs nothing.
-ws_bad="$(grep -rln "//\[\$' " "$ROOT"/scripts "$ROOT"/hooks 2>/dev/null | sed "s|$ROOT/||" | tr '\n' ' ')"
+# cloud-debug has the same shape on $LOGS — raw `gcloud logging read` output, checked
+# BEFORE the 200 KB cap is applied, so it was the worse of the two. Review found it while
+# reading the fix for the delegate; no test could have, because the `big` gcloud mode is
+# solid 'A' inside JSON with no whitespace at all.
+cd_t0="$(python3 -c 'import time; print(time.time())')"
+# NOT --print-command: that exits at cloud-debug.sh:168, before LOGS is even fetched at
+# 179, so the check under test is never reached and the assertion passes on nothing. The
+# first version of this test did exactly that and stayed green with the fix removed.
+cd_rc="$(GCLOUD_MODE=bigws ws_bounded 30 "$ROOT/scripts/cloud-debug.sh" --service svc)"
+cd_secs="$(python3 -c "print('%.1f' % ($(python3 -c 'import time; print(time.time())') - $cd_t0))")"
+if [ "$cd_rc" = 0 ]; then
+  echo "ok: a large whitespace-bearing log payload completes (${cd_secs}s)"; PASS=$((PASS+1));
+else echo "FAIL: cloud-debug pinned the CPU on a large log payload (rc=$cd_rc after ${cd_secs}s)"; FAIL=$((FAIL+1)); fi
+
+# ...and the shipped scripts must not reintroduce the shape anywhere else.
+#
+# Match the SHAPE, not one spelling. The first version looked for the ANSI-C form only and
+# reported all-clear while `${LOGS//[[:space:]]/}` sat in cloud-debug.sh doing the same
+# thing to raw `gcloud logging read` output — measured at the same cost, and ahead of the
+# 200 KB cap, so it was the worse of the two. Review found it; the guard could not.
+#
+# A line may opt out with `# ws-strip-ok:` and a reason. cloud-debug keeps one, reached
+# only when the string is already known to be whitespace and brackets.
+# Comments are stripped first, and the marker is read BEFORE that — the lines explaining
+# why this shape is gone all quote it, and an unstripped grep reports the explanation as
+# the offence. That is the same trap the `sort -V` guard fell into.
+ws_bad=""
+for wsf in "$ROOT"/scripts/*.sh "$ROOT"/hooks/*.sh; do
+  [ -f "$wsf" ] || continue
+  hit="$(grep -vn 'ws-strip-ok:' "$wsf" | sed 's/#.*//' \
+         | grep -n '\${[A-Za-z_][A-Za-z0-9_]*//\[' | cut -d: -f1 | tr '\n' ',')"
+  [ -n "$hit" ] && ws_bad="$ws_bad ${wsf#"$ROOT"/}"
+done
 if [ -z "$ws_bad" ]; then
   echo "ok: no shipped script deletes whitespace to test for it"; PASS=$((PASS+1));
 else echo "FAIL: whitespace-deleting substitution is back in:$ws_bad"; FAIL=$((FAIL+1)); fi

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -921,17 +921,23 @@ else echo "FAIL: cloud-debug pinned the CPU on a large log payload (rc=$cd_rc af
 # comments quietly narrowed it to the top level, so a script added under scripts/<sub>/
 # would have escaped. Nothing is nested today — the point is that nothing has to stay
 # that way for the guard to hold. Reviewers caught the narrowing.
-ws_bad=""
+ws_bad=""; ws_seen=0
 while IFS= read -r wsf; do
   [ -n "$wsf" ] || continue
+  ws_seen=$((ws_seen+1))
   hit="$(grep -vn 'ws-strip-ok:' "$wsf" | sed 's/#.*//' \
          | grep -n '\${[A-Za-z_][A-Za-z0-9_]*//\[' | cut -d: -f1 | tr '\n' ',')"
   [ -n "$hit" ] && ws_bad="$ws_bad ${wsf#"$ROOT"/}"
 done <<EOF
 $(find "$ROOT/scripts" "$ROOT/hooks" -name "*.sh" -type f 2>/dev/null)
 EOF
-if [ -z "$ws_bad" ]; then
-  echo "ok: no shipped script deletes whitespace to test for it"; PASS=$((PASS+1));
+# find's stderr is discarded, so a bad path or an unreadable directory would give the
+# loop nothing and the guard would report all-clear having scanned zero files.
+# Count what it saw. Reviewers caught the vacuous pass.
+if [ "$ws_seen" -lt 8 ]; then
+  echo "FAIL: the whitespace guard scanned only $ws_seen files — it found nothing to check"; FAIL=$((FAIL+1));
+elif [ -z "$ws_bad" ]; then
+  echo "ok: no shipped script deletes whitespace to test for it ($ws_seen files)"; PASS=$((PASS+1));
 else echo "FAIL: whitespace-deleting substitution is back in:$ws_bad"; FAIL=$((FAIL+1)); fi
 
 echo "== --sandbox is not sold as containment =="

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -917,13 +917,19 @@ else echo "FAIL: cloud-debug pinned the CPU on a large log payload (rc=$cd_rc af
 # Comments are stripped first, and the marker is read BEFORE that — the lines explaining
 # why this shape is gone all quote it, and an unstripped grep reports the explanation as
 # the offence. That is the same trap the `sort -V` guard fell into.
+# find, not a flat glob. The first version used `grep -r`; rewriting it per-file to strip
+# comments quietly narrowed it to the top level, so a script added under scripts/<sub>/
+# would have escaped. Nothing is nested today — the point is that nothing has to stay
+# that way for the guard to hold. Reviewers caught the narrowing.
 ws_bad=""
-for wsf in "$ROOT"/scripts/*.sh "$ROOT"/hooks/*.sh; do
-  [ -f "$wsf" ] || continue
+while IFS= read -r wsf; do
+  [ -n "$wsf" ] || continue
   hit="$(grep -vn 'ws-strip-ok:' "$wsf" | sed 's/#.*//' \
          | grep -n '\${[A-Za-z_][A-Za-z0-9_]*//\[' | cut -d: -f1 | tr '\n' ',')"
   [ -n "$hit" ] && ws_bad="$ws_bad ${wsf#"$ROOT"/}"
-done
+done <<EOF
+$(find "$ROOT/scripts" "$ROOT/hooks" -name "*.sh" -type f 2>/dev/null)
+EOF
 if [ -z "$ws_bad" ]; then
   echo "ok: no shipped script deletes whitespace to test for it"; PASS=$((PASS+1));
 else echo "FAIL: whitespace-deleting substitution is back in:$ws_bad"; FAIL=$((FAIL+1)); fi

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -110,6 +110,12 @@ case "${STUB_MODE:-text}" in
   badmodel) echo "Error: invalid --model \"X\": model X is not recognized as a known model" >&2; exit 1 ;; # -> exit 14
   softdeny) echo "no output produced — a tool required the \"write_file\" permission that headless mode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow" >&2; exit 0 ;; # rc=0 + empty stdout -> exit 15
   big)     printf 'x%.0s' $(seq 1 20000); echo ;;    # dump-sized reply -> digest guard warns
+  # Dump-sized AND whitespace-bearing. `big` above is 20 KB of solid 'x', and $( ) strips
+  # its one trailing newline, so the captured value contains NO whitespace at all — which
+  # is exactly the case bash 3.2's substitution handles fast. That is why 305 tests on a
+  # 3.2.57 machine never saw issue #66. Measured: same 8 KB, 0% whitespace 0.04s, 2% or
+  # more 21-25s. A regression test for this has to carry whitespace.
+  bigws)   printf 'word %.0s' $(seq 1 3400) ;;
   # agy >= 1.1.8 structured envelope. Note the RAW newline inside "response" — agy really
   # emits that, and it makes the payload invalid for strict JSON parsers.
   json_ok)  printf '{"conversation_id":"c1","status":"SUCCESS","response":"JSONBODY\n","usage":{"input_tokens":10,"output_tokens":2,"thinking_tokens":1,"cache_read_tokens":3,"total_tokens":16}}'; exit 0 ;;
@@ -844,6 +850,36 @@ check "bin/cloud-debug forwards to cloud-debug.sh (no CLAUDE_PLUGIN_ROOT)" 0 "$r
 out=$(env -u CLAUDE_PLUGIN_ROOT "$BIN/measure-session" 2>&1 | head -1)
 case "$out" in *measure-session*) echo "ok: bin/measure-session forwards to the .py"; PASS=$((PASS+1));;
   *) echo "FAIL: bin/measure-session did not forward (got: '$out')"; FAIL=$((FAIL+1));; esac
+
+echo "== the whitespace check does not pin a CPU (issue #66, bash 3.2) =="
+# `${OUT//[$' \t\n\r']/}` answers "is this only whitespace?" by rewriting the whole
+# string. On the bash macOS ships — 3.2.57, frozen in 2007, and what /usr/bin/env bash
+# resolves to on a stock Mac — that is catastrophically slow as soon as the string
+# contains ONE whitespace character: measured on this machine, 8 KB took 24s and every
+# doubling cost ~6x. Reported wrappers held a core at 99% for over two hours after agy had
+# already finished successfully.
+#
+# It is also not interruptible: bash cannot service SIGTERM inside the substitution, so
+# `timeout 90` on the run above returned only after 205s. No wall-clock guard can bound
+# it, which is why `agy-job status` kept reporting `running`.
+#
+# The bound is generous on purpose — the fixed path is ~0.9s here and the broken one is
+# minutes, so anything in between separates them. -k forces a KILL so a regression fails
+# in 35s instead of hanging CI for the full 205.
+ws_dir="$TMP/wsbench"; rm -rf "$ws_dir"; mkdir -p "$ws_dir"
+ws_t0="$(python3 -c 'import time; print(time.time())')"
+STUB_MODE=bigws timeout -k 5 30 "$DELEGATE" "hi" >/dev/null 2>&1; ws_rc=$?
+ws_t1="$(python3 -c 'import time; print(time.time())')"
+ws_secs="$(python3 -c "print('%.1f' % ($ws_t1 - $ws_t0))")"
+if [ "$ws_rc" != 124 ] && [ "$ws_rc" != 137 ]; then
+  echo "ok: a 17KB whitespace-bearing reply completes (${ws_secs}s)"; PASS=$((PASS+1));
+else echo "FAIL: the whitespace check pinned the CPU on a 17KB reply (rc=$ws_rc after ${ws_secs}s)"; FAIL=$((FAIL+1)); fi
+# ...and the shipped scripts must not reintroduce the shape anywhere else. Scoped to what
+# ships: this file uses it once on a 30-line workflow snippet, where it costs nothing.
+ws_bad="$(grep -rln "//\[\$' " "$ROOT"/scripts "$ROOT"/hooks 2>/dev/null | sed "s|$ROOT/||" | tr '\n' ' ')"
+if [ -z "$ws_bad" ]; then
+  echo "ok: no shipped script deletes whitespace to test for it"; PASS=$((PASS+1));
+else echo "FAIL: whitespace-deleting substitution is back in:$ws_bad"; FAIL=$((FAIL+1)); fi
 
 echo "== --sandbox is not sold as containment =="
 # 0.25.0 deferred adding --sandbox to agy-media because agy could not run. It runs now,


### PR DESCRIPTION
Follow-up to **#67** by @MoonCaves, which is merged. The fix is theirs; this only stops it coming back.

The external review on #67 said the existing suite already pins this behaviour. It pins the **answer**, not the **cost** — and the cost was the bug. Both tests below were verified by reverting #67.

## Why 305 tests on a bash-3.2 machine saw nothing

This is the part worth recording. `big` already emits 20 KB, so it looks like it should have caught this. It never could:

| 8 KB payload | `${OUT//[ws]/}` on 3.2.57 |
|---|---|
| 0% whitespace (solid `x`) | **0.04 s** |
| 2% whitespace | 25.2 s |
| 20% | 24.8 s |
| 100% | 21.5 s |

The cost switches on **whether there is a match at all**, not on how many. And `big` is solid `x` plus one trailing newline that `$( )` strips — so the captured value contains no whitespace, and the suite's only large fixture sat on the only fast side of the cliff.

The new `bigws` stub is the same size *with* whitespace.

## It is also not interruptible

bash cannot service SIGTERM inside the substitution. `timeout 90` around the reverted wrapper returned after **205 s**, not 90. No wall-clock guard could have bounded this — which is why @MoonCaves saw `agy-job status` reporting `running` throughout, and why the guard on the agy child was never going to help.

The test does **not** use GNU `timeout` — stock macOS does not ship it, and stock macOS is exactly the platform bash 3.2 lives on, so keying on it would report ok on rc=127 without running anything. A `ws_bounded()` helper backgrounds the run and kills it from the suite, which works everywhere. A regression fails in 30 s instead of hanging CI for the full 205.

## The two tests

- **behavioural** — a 17 KB whitespace-bearing reply must complete. 0.2 s on master; killed at 35 s with #67 reverted.
- **static** — no shipped script may test for whitespace by deleting it. Scoped to `scripts/` and `hooks/`: `run-tests.sh` itself uses the substitution once on a 30-line workflow snippet, where it costs nothing.

305 → **308**.

## Added after review

Reviewers found a **second live instance** that neither the reporter nor I had: `cloud-debug.sh` ran the same strip on raw `gcloud logging read` output, *ahead* of its own 200 KB cap — the worse of the two. The POSIX-class spelling costs the same as the ANSI-C one (23.8 s vs 24.4 s at 8 KB), and the first static guard matched only the ANSI-C form, so it reported all-clear over it. The guard now matches the shape, strips comments first, scans recursively, and honours an inline `# ws-strip-ok:` opt-out that the behavioural tests still police.

Two of mine, both caught by mutation rather than by reading: `[![:space:][]]` looks right and is not (the `]` closes the expression early, so plain `x` read as "no logs"), and the cloud-debug test first used `--print-command`, which exits before `LOGS` is fetched — so it never reached the code and stayed green with the fix removed.