### PR TITLE
ci: macOS bash 3.2 job, zizmor, Dependabot, labeler, greetings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Every action in .github/workflows is pinned to a commit SHA with a "# vN" comment.
+# A pin nobody updates is a pin that rots; Dependabot bumps the SHAs (and the comment)
+# in one grouped PR a week. Review workflows will run on those PRs like any other.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels: [ci]
+    commit-message:
+      prefix: "ci(deps)"
+    open-pull-requests-limit: 5

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,36 @@
+# Path -> label map for actions/labeler (workflow: .github/workflows/labeler.yml).
+# Globs are minimatch; a label is added when ANY listed glob matches ANY changed file.
+# `documentation` and `security` are the repository's existing labels; the rest were
+# created for this map. Labels are added, never removed (sync-labels is off), so a
+# label a maintainer sets by hand stays.
+wrapper:
+  - changed-files:
+      - any-glob-to-any-file: ['scripts/**', 'bin/**']
+hooks:
+  - changed-files:
+      - any-glob-to-any-file: ['hooks/**']
+skill:
+  - changed-files:
+      - any-glob-to-any-file: ['skills/**', 'commands/**', 'agents/**', '.claude-plugin/**']
+tests:
+  - changed-files:
+      - any-glob-to-any-file: ['tests/**']
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: ['docs/**', 'README.md', 'CHANGELOG.md', 'CONTRIBUTING.md', 'SECURITY.md']
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/**']
+experiments:
+  - changed-files:
+      - any-glob-to-any-file: ['experiments/**']
+pricing:
+  - changed-files:
+      - any-glob-to-any-file: ['prices.json', 'scripts/agy-cost-compare.sh']
+security:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'hooks/validate-delegate-bash.sh'
+          - 'SECURITY.md'
+          - '.github/workflows/claude-review-external.yml'
+          - '.github/workflows/quorum-review.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,17 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    name: Tests + lint (ubuntu)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
 
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
@@ -32,3 +38,28 @@ jobs:
 
       - name: Tests (stubs agy; no network)
         run: bash tests/run-tests.sh
+
+  # CONTRIBUTING targets /bin/bash 3.2 and BSD userland and says outright that testing
+  # on Linux only will not catch violations. 0.25.2's CPU spin reproduced only on
+  # 3.2.57. This job runs the same suite on macOS with the SYSTEM bash first on PATH,
+  # so every `#!/usr/bin/env bash` in scripts/ and tests/ resolves to 3.2 and not to
+  # the Homebrew bash 5 the runner image also ships.
+  test-macos:
+    name: Tests (macOS, /bin/bash 3.2)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+
+      - name: Put /bin/bash 3.2 first on PATH; make sure gtimeout exists
+        run: |
+          mkdir -p "$HOME/bash32" && ln -sf /bin/bash "$HOME/bash32/bash"
+          echo "$HOME/bash32" >> "$GITHUB_PATH"
+          command -v gtimeout >/dev/null 2>&1 || brew install coreutils
+          /bin/bash --version | head -1
+
+      - name: Tests (stubs agy; no network)
+        run: |
+          bash --version | head -1     # must say 3.2.x, or the job is not testing what it claims
+          bash tests/run-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,13 @@ jobs:
 
       - name: Tests (stubs agy; no network)
         run: |
-          bash --version | head -1     # must say 3.2.x, or the job is not testing what it claims
+          # Gate, not a printout: if the PATH shim above ever stops shadowing Homebrew's
+          # bash 5, the suite would run on the wrong shell and this job would still be
+          # green while CONTRIBUTING tells contributors it proves 3.2 compatibility.
+          v="$(bash --version | head -1)"
+          echo "$v"
+          case "$v" in
+            *"version 3.2."*) ;;
+            *) echo "::error::expected /bin/bash 3.2.x first on PATH, got: $v" >&2; exit 1 ;;
+          esac
           bash tests/run-tests.sh

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,43 @@
+# Greets first-time issue authors and first-time PR authors. pull_request_target is
+# needed so a fork PR can be commented on (a pull_request token is read-only there);
+# no checkout, no run: steps, so PR code is never executed. The messages point at the
+# three things every agy bug report needs and at CONTRIBUTING's pre-PR checklist.
+name: greetings
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:   # zizmor: ignore[dangerous-triggers] -- no checkout, no code execution
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  greet:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d  # v3.1.0
+        with:
+          issue_message: |
+            Thanks for opening your first issue here.
+
+            agy changes behaviour every few releases, so to reproduce anything we need three things. If they are not in the report yet, please add them:
+
+            - `agy --version` and your OS (macOS / Linux / WSL — native Windows is not supported for headless delegation)
+            - the exact command you ran (for example `agy-delegate --tier flash --dir . "..."`) and its stderr — the `AGY_SIGNAL` and `AGY_USAGE` lines matter
+            - what you expected and what happened instead
+
+            `agy-doctor` output helps too. Thanks!
+          pr_message: |
+            Thanks for your first pull request.
+
+            Before review, please check the items from CONTRIBUTING.md:
+
+            - `bash tests/run-tests.sh` passes (it stubs `agy`, no network) and `shellcheck --severity=error scripts/*.sh tests/*.sh hooks/*.sh` is clean. CI runs both, on Ubuntu and on macOS `/bin/bash` 3.2.
+            - If behaviour changed, `README.md`, `skills/antigravity/SKILL.md` and `CHANGELOG.md` say so, and any claim about `agy` states what was measured and on which version.
+            - Target bash 3.2 and BSD userland: no `declare -A`, `mapfile`, `${var^^}` or GNU-only flags.
+
+            Automated review starts on its own for PRs from this repository. For PRs from forks a maintainer approves the run first, so a quiet check is not a rejection.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,21 @@
+# Labels pull requests by the paths they touch (map: .github/labeler.yml).
+# pull_request_target is what lets it label PRs from forks — and for exactly that
+# reason this workflow must never check out or execute PR code: no actions/checkout,
+# no run: steps, only the labeler reading the changed-file list through the API.
+# The labels must already exist (there is no issues: write here).
+name: labeler
+
+on:
+  pull_request_target:   # zizmor: ignore[dangerous-triggers] -- no checkout, no code execution
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read         # read .github/labeler.yml from the base branch
+      pull-requests: write   # add labels
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13  # v7.0.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,45 @@
+# GitHub Actions security analysis. Three workflows here run on pull_request_target /
+# issue_comment with OIDC and App tokens, and the changelog records two incidents in
+# exactly that area (#58, #63). zizmor audits the workflow FILES: template injection,
+# dangerous triggers, unpinned actions, persisted credentials, over-broad App tokens.
+# Results go to the Security tab as code scanning alerts; the job does not fail on
+# findings, because the baseline has known ones to triage first. Fork PRs get the
+# console report only (their token cannot upload SARIF).
+name: zizmor
+
+on:
+  push:
+    branches: [master]
+    paths: ['.github/**']
+  pull_request:
+    paths: ['.github/**']
+  schedule:
+    - cron: '17 6 * * 1'     # weekly: new audits land upstream often
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # SARIF upload
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+
+      - name: zizmor (upload to code scanning)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99  # v0.6.3
+        with:
+          inputs: .github/workflows
+
+      - name: zizmor (fork PR — console only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99  # v0.6.3
+        with:
+          inputs: .github/workflows
+          advanced-security: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ bash tests/run-tests.sh          # dependency-free; stubs `agy`, no network
 shellcheck scripts/*.sh tests/*.sh   # CI gates on --severity=error
 ```
 
-- **Tests pass** and shellcheck is clean (CI runs both — see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)).
+- **Tests pass** and shellcheck is clean (CI runs both — see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)). CI runs the suite on Ubuntu **and** on macOS `/bin/bash` 3.2, so a bash-4-ism fails there even if it passed for you on Linux.
 - If you touch a manifest, `python3 -c "import json; json.load(open('.claude-plugin/plugin.json'))"` (and `marketplace.json`, `prices.json`) still parse.
 - **Keep the skill honest.** [`skills/antigravity/SKILL.md`](skills/antigravity/SKILL.md) is the plugin's brain — if behavior changes, update it. Don't claim a capability the code doesn't have.
 - **Cost numbers are estimates.** If you quote figures, say so and point at `prices.json`.
@@ -53,7 +53,8 @@ shellcheck scripts/*.sh tests/*.sh   # CI gates on --severity=error
 - **Target bash 3.2.** macOS still ships `/bin/bash` 3.2.57 (GPLv3 is why), and macOS is a
   supported platform, so `declare -A`, `readarray`/`mapfile`, `${var^^}` and friends are out.
   Same for GNU-only flags on `sed`, `date` and `grep` — BSD userland is the floor. Testing on
-  Linux only will not catch these.
+  Linux only will not catch these; CI's macOS job does, but run the suite on 3.2 locally when
+  you can.
 - New scripts get a `usage()` and a test in `tests/run-tests.sh`.
 
 ## Reporting bugs / ideas


### PR DESCRIPTION
Five pieces of repository automation, each its own commit. None of them changes plugin behaviour; the point is to catch the two classes of defect this repository has actually shipped — bash-3.2-only bugs and workflow-security slips — before a reviewer has to.

## 1. CI runs the suite on macOS `/bin/bash` 3.2

CONTRIBUTING targets 3.2 and BSD userland and says outright that "testing on Linux only will not catch these". CI ran on Ubuntu alone, and 0.25.2's CPU spin reproduced only on 3.2.57. A second job now runs the same suite on `macos-latest` with the **system** bash first on PATH, so every `#!/usr/bin/env bash` resolves to 3.2 and not to the Homebrew bash 5 the image also ships; it prints the version it is testing with. `gtimeout` is installed only if missing (the hang-guard tests skip without it). The checkout action is pinned to the SHA the review workflows already use, with `persist-credentials: false`, and the workflow declares `contents: read`.

## 2. zizmor audits the workflows themselves

Three workflows run on `pull_request_target` / `issue_comment` with OIDC and App tokens, and the changelog records two incidents there (#58, #63). zizmor audits the workflow files — template injection, dangerous triggers, unpinned actions, persisted credentials, over-broad App tokens — and uploads SARIF to the Security tab on pushes to master, same-repo PRs touching `.github/`, and weekly. Fork PRs get the console report only (their token cannot upload).

**It does not fail the job on findings**, because the baseline already has some. Running zizmor 1.30.0 on the existing review workflows today:

| finding | where |
|---|---|
| `unpinned-uses` — `actions/checkout@v4`, `anthropics/claude-code-action@v1` | `claude-review.yml:26,30` |
| `github-app` — App token without any `permission-*` input, inherits the installation's permissions | `quorum-review.yml:186` |
| `excessive-permissions` — top-level `permissions:` broader than the jobs need | `claude-review-external.yml:44,45` |
| `dangerous-triggers` — `pull_request_target` | `claude-review-external.yml:38` (by design; gated) |
| `artipacked` — checkout persists credentials | `claude-review.yml:26`, `claude-review-external.yml:137` |

These will appear as code scanning alerts once this merges. They are better fixed in a follow-up than by turning CI red on the day this lands; the three new workflows in this PR are zizmor-clean.

## 3. Dependabot for GitHub Actions

Every action is pinned to a commit SHA with a `# vN` comment; a pin nobody updates is a pin that rots. Dependabot bumps the SHAs (and the comments) in one grouped PR a week (Monday 09:00 JST), labelled `ci`, `ci(deps)` prefix. Note: the review workflows will run on those PRs like any other.

## 4. Labeler

`wrapper` / `hooks` / `skill` / `tests` / `documentation` / `ci` / `experiments` / `pricing`, plus the existing `security` label for the delegate Bash gate, `SECURITY.md` and the two gated review workflows. Labels are only added, never removed, so a label a maintainer sets by hand stays. `pull_request_target` so fork PRs are labelled too — and for exactly that reason the workflow has **no checkout and no `run:` steps**; it reads the changed-file list through the API with `pull-requests: write`. The seven new labels exist in the repository already; the workflow does not hold `issues: write`.

## 5. Greetings

A first issue author is told the three things every agy report needs (`agy --version` and OS, the exact command with its `AGY_SIGNAL` / `AGY_USAGE` stderr, expected vs actual). A first PR author gets CONTRIBUTING's pre-review checklist and is told that automated review on a fork PR waits for a maintainer's approval, so a quiet check is not a rejection. `pull_request_target`, no checkout, no `run:` steps.

## Verified

- All YAML parses; the four new/changed workflows are **zizmor-clean** (`No findings to report`, 1 documented ignore each for the two `pull_request_target` workflows).
- Labeler globs checked against 19 representative paths (minimatch-equivalent): each lands on the intended label(s), `LICENSE` on none.
- `bash tests/run-tests.sh`: 315 / 315 on the branch.
- The macOS job runs for the first time on this PR — see the check.
