### PR TITLE
ci: skip review workflows on Dependabot runs; clear the zizmor baseline

### DIFF
--- a/.github/workflows/claude-review-external.yml
+++ b/.github/workflows/claude-review-external.yml
@@ -60,9 +60,12 @@ permissions: {}
 # A label event never makes a running review obsolete: the head commit is unchanged. Only
 # a push does. And `false` does not DISCARD the second run, it queues it — so an unrelated
 # label waits its turn and then skips, costing a few seconds of a queue slot.
+#
+# And not when the push is Dependabot's: `authorise` skips that run, and a run that
+# skips must not cancel a live review (same term as the job condition).
 concurrency:
   group: claude-review-ext-${{ github.event.pull_request.number }}
-  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
+  cancel-in-progress: ${{ github.event.action == 'synchronize' && github.actor != 'dependabot[bot]' }}
 
 jobs:
   # Cheap gate, separate job: nothing with secrets runs until this passes.

--- a/.github/workflows/claude-review-external.yml
+++ b/.github/workflows/claude-review-external.yml
@@ -36,13 +36,16 @@ name: Claude review (external, gated)
 #     Without it a contributor gets one clean review and can then push anything: the
 #     review stays on the PR looking current while describing an older head.
 on:
-  pull_request_target:
+  # The trust model for this trigger is the comment above: the fork's tree never
+  # reaches the runner, and `authorise` checks that whoever applied the label has
+  # write access before anything with secrets runs. Hence the zizmor ignore.
+  pull_request_target:   # zizmor: ignore[dangerous-triggers]
     types: [labeled, synchronize]
 
-permissions:
-  contents: read
-  pull-requests: write
-  id-token: write   # the action mints an OIDC token even with token auth
+# Nothing at workflow level: each job asks for exactly what it uses (zizmor
+# excessive-permissions). `authorise` always did; `review` now carries what the
+# workflow used to grant to both jobs.
+permissions: {}
 
 # One review at a time per pull request. `cancel-in-progress` is evaluated BEFORE any job
 # condition, so a run that will be skipped still enters the group and can cancel a live
@@ -65,7 +68,10 @@ jobs:
   # Cheap gate, separate job: nothing with secrets runs until this passes.
   authorise:
     # Run when the label is applied, or on any push to a PR that already carries it.
+    # ... and never for a push by Dependabot to a labelled pull request: a run it
+    # triggers carries no repository secrets (#72), so the review could not authenticate.
     if: >-
+      github.actor != 'dependabot[bot]' &&
       contains(github.event.pull_request.labels.*.name, 'claude-review') &&
       (github.event.action == 'synchronize' || github.event.label.name == 'claude-review')
     runs-on: ubuntu-latest
@@ -132,13 +138,19 @@ jobs:
   review:
     needs: authorise
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write   # the action mints an OIDC token even with token auth
     steps:
       # Trusted: the base repo, at the workspace root (the action expects a git repo here).
+      # No credentials left in the clone: the action receives `github_token` explicitly below.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
-      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b  # v1
+      - uses: anthropics/claude-code-action@ef8bb1e43bf303cff727a1dd0b8837029fe982a2  # v1.0.215
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Pass the GitHub token explicitly instead of letting the action mint one.
@@ -148,9 +160,9 @@ jobs:
           # every run — and returned `401 Unauthorized - Invalid OIDC token` on all three
           # attempts here, the first time this workflow ever reached the action at all
           # (before that it died at the checkout guard, then at the concurrency bug
-          # above). The action version is not the difference: the 26 commits between this
-          # pin and the tag the internal workflow resolves touch `workflow_run` support,
-          # not the token exchange.
+          # above). The action version was not the difference: when this was measured the
+          # two workflows' pins were 26 commits apart, all in `workflow_run` support, not
+          # the token exchange. Both pin the same commit now.
           #
           # `github_token` is documented as "optional if using GitHub App", and upstream
           # recommends passing it for the analogous privileged context (`workflow_run`

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,6 +4,12 @@ name: Claude review (internal)
 # Fork PRs are deliberately excluded here — on `pull_request` they get no secrets, so
 # the action can't authenticate anyway. They are handled by the label-gated workflow
 # in claude-review-external.yml, which requires an explicit human approval.
+#
+# A pull request that EDITS THIS FILE is not reviewed by it. The action refuses to run
+# a workflow whose content differs from the default branch's ("Workflow validation
+# failed ... identical content"), skips itself and still reports the job green — the
+# green check on such a PR says nothing about the change. Measured on #73: a change to
+# this file's pins and checkout options was first exercised by the next PR after merge.
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,10 +13,15 @@ permissions:
   pull-requests: write
   id-token: write   # the action mints an OIDC token even with token auth
 
-# One review per PR; a new push supersedes the previous run.
+# One review per PR; a new push supersedes the previous run — unless the push is
+# Dependabot's. `cancel-in-progress` is evaluated BEFORE the job's `if:`, so a run
+# the job will skip still enters the group and cancels a live one (#42, #53). A
+# Dependabot push would cancel a maintainer's in-flight review and then skip
+# itself, leaving the pull request with no review and nothing saying why. The
+# single term below mirrors the single term added to the job condition.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' }}
 
 jobs:
   review:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,14 +20,24 @@ concurrency:
 
 jobs:
   review:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Not on Dependabot's pull requests. A run Dependabot triggers gets Dependabot's
+    # secrets, not the repository's (the log says `Secret source: Dependabot`), so the
+    # action cannot authenticate and the check goes red on every weekly bump (#72).
+    # `github.actor` is the bot only when the bot's own push triggered the run.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      # Pinned to a commit like every other action in this repository (zizmor
+      # unpinned-uses); Dependabot bumps it. No git credentials are left in the clone:
+      # the action authenticates on its own, and this job cannot push anyway.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@ef8bb1e43bf303cff727a1dd0b8837029fe982a2  # v1.0.215
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Surfaces the real API error instead of a bare is_error:true (the action

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -64,12 +64,17 @@ on:
 # and a run that turns out to be skippable costs a few seconds of a queue slot.
 #
 # One rule, nothing to keep in sync, and it subsumes both #42 and #53.
+#
+# One exception, added with the Dependabot skip on the job: a push BY Dependabot is
+# a run the job will skip, and a skipped run must not cancel anything — a human's
+# `@quorum /review` on a Dependabot pull request would otherwise be cancelled by the
+# bot's next rebase and never replaced. Same single term as the job's `if:`.
 concurrency:
   group: >-
     quorum-review-${{ github.event.pull_request.number
       || github.event.issue.number
       || github.event.inputs.pr }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
 
 permissions:
   contents: read

--- a/.github/workflows/quorum-review.yml
+++ b/.github/workflows/quorum-review.yml
@@ -80,7 +80,12 @@ permissions:
 
 jobs:
   review:
+    # Not on a run Dependabot triggered: it carries Dependabot's secrets, not the
+    # repository's (`Secret source: Dependabot` in the log), so the App private key is
+    # empty and the job dies at "Mint an App installation token" (#72). A human's
+    # `@quorum /review` on a Dependabot pull request still runs: the actor is the human.
     if: >-
+      github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.fork != true &&
       (github.event_name == 'pull_request' ||
        github.event_name == 'workflow_dispatch' ||
@@ -187,6 +192,12 @@ jobs:
         with:
           app-id: ${{ vars.QUORUM_APP_ID }}
           private-key: ${{ secrets.QUORUM_APP_PRIVATE_KEY }}
+          # Requested explicitly, so the token is capped at what the review uses even
+          # if the installation is ever granted more (zizmor github-app). These are the
+          # three the App holds today; asking for one it lacks would fail the mint.
+          permission-metadata: read
+          permission-contents: read
+          permission-pull-requests: write
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1717,10 +1717,21 @@ if grep -qE '^ +github_token: \$\{\{ *github\.token *\}\}' "$XW"; then
   echo "ok: external review uses the workflow-scoped GITHUB_TOKEN"; PASS=$((PASS+1));
 else echo "FAIL: external review has no explicit github_token — it will mint an App token"; FAIL=$((FAIL+1)); fi
 # ...and the permissions that token is scoped BY have to actually cover posting a review.
-XPERM="$(sed -n '/^permissions:/,/^concurrency:/p' "$XW")"
-if grep -q 'pull-requests: write' <<<"$XPERM"; then
-  echo "ok: the workflow grants pull-requests: write for the review comment"; PASS=$((PASS+1));
+# They live on the `review` JOB: the workflow-level block is `{}` since the zizmor
+# cleanup, so a read of that block would pass on nothing (or, worse, find the write it
+# is looking for in a block that no longer scopes the job). Read the job's block, from
+# `  review:` to its `steps:`, and refuse to pass on an empty read.
+XPERM="$(sed -n '/^  review:/,/^    steps:/p' "$XW")"
+if [ -z "${XPERM//[$' \t\n']/}" ]; then
+  echo "FAIL: could not read the external review job's block"; FAIL=$((FAIL+1));
+elif grep -q 'pull-requests: write' <<<"$XPERM"; then
+  echo "ok: the review job grants pull-requests: write for the review comment"; PASS=$((PASS+1));
 else echo "FAIL: GITHUB_TOKEN cannot post the review with these permissions"; FAIL=$((FAIL+1)); fi
+# And the workflow level stays empty, so a write permission cannot quietly come back for
+# every job at once (zizmor excessive-permissions, cleared in the same change).
+if grep -qE '^permissions: *\{\}' "$XW"; then
+  echo "ok: external workflow-level permissions are empty; jobs declare their own"; PASS=$((PASS+1));
+else echo "FAIL: external workflow grants permissions at workflow level again"; FAIL=$((FAIL+1)); fi
 
 # The fork guard runs before anything is cloned or any credential is minted.
 if [ "$(grep -n 'Refuse a fork' "$QW" | cut -d: -f1)" \


### PR DESCRIPTION
Follow-up to #71 / #72: the two things the Dependabot PR surfaced.

## 1. Review workflows skip runs Dependabot triggers — and never cancel a review they will not replace

A run Dependabot triggers gets Dependabot's secrets, not the repository's (`Secret source: Dependabot` in the log). On #72 quorum-review died at "Mint an App installation token" with an empty private key, and it would do so on every weekly bump. All three review workflows now carry `github.actor != 'dependabot[bot]'` in their job condition. A human's `@quorum /review` on such a PR still runs — the actor is then the human.

Review caught the race that skip alone introduces: `cancel-in-progress` is evaluated **before** the job's `if:`, so a run Dependabot triggers would still enter the concurrency group, cancel the review in flight (a maintainer's push on claude-review, a human's `@quorum /review`, a labelled external review) and then skip itself — #42 / #53 in a new disguise. All three concurrency expressions now carry the same single term, so the run that will skip never cancels. The existing guards on the concurrency blocks still pass.

## 2. The zizmor baseline (9 alerts) is cleared

Each addressed rather than silenced, except the one that is the design:

| alert | fix |
|---|---|
| `unpinned-uses` ×2 (`claude-review.yml`) | `actions/checkout` → `3d3c42e5… # v7.0.1`, `claude-code-action` → `ef8bb1e4… # v1.0.215` (what `@v1` resolves to today) |
| `ref-version-mismatch` (`claude-review-external.yml`) | pinned to the same `v1.0.215` commit as the internal workflow; the two had drifted 26 commits apart, which is what the alert was pointing at. The inline comment that explained the old drift is updated, not deleted. |
| `artipacked` ×2 | `persist-credentials: false` on both review checkouts — the internal job cannot push, the external one passes `github_token` explicitly |
| `excessive-permissions` ×2 (`claude-review-external.yml`) | workflow-level `permissions:` → `{}`; the `review` job carries exactly what the workflow used to grant (`authorise` already had its own narrower block). Moved, not changed. The test-suite guard that read the workflow-level block now reads the job's, refuses to pass on an empty read, and a second assertion pins the workflow level empty (315 → 316, both mutation-killed). |
| `github-app` (`quorum-review.yml`) | `permission-metadata: read`, `permission-contents: read`, `permission-pull-requests: write` on the App token — what the installation holds today, so the token stays capped if the App is ever granted more |
| `dangerous-triggers` (`claude-review-external.yml`) | kept, with `# zizmor: ignore[dangerous-triggers]` and the trust model spelled out beside it: the fork's tree never reaches the runner, and `authorise` checks that the label's applier has write access |

`zizmor .github/workflows` on this branch: **No findings** (two documented ignores). Code scanning shows 0 open zizmor alerts on the PR ref.

## What this PR verifies, and what it does not

- **Verified live here:** `quorum-review` ran on every push with the capped App token (the mint step succeeded; two full reviews posted). CI (Ubuntu + macOS 3.2) and zizmor pass. The Dependabot skip itself is verified by construction (a single actor term); its effect will be visible on the next Monday bump.
- **NOT exercised by this PR, contrary to the first version of this description:** `Claude review (internal)`. The action refuses to run a workflow whose content differs from the default branch's ("Workflow validation failed … identical content"), skips itself and still reports the job green — the same happened on #72, which also touched this file. So the new `v1.0.215` pin (published 2026-09-03 23:50 UTC, after the last real run here) and `persist-credentials: false` are first exercised by the **next PR after merge**. The file now says so at the top. If that first review does not post, revert those two lines of `claude-review.yml`.
- **By construction only:** `claude-review-external.yml` runs only on labelled fork PRs. Its permissions were moved, not changed; it pins the same commit as the internal workflow.
- Not touched: the workflows' triggers, prompts, tools.
